### PR TITLE
Extend lint/format tooling and enforce it on pre-commit

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,7 @@ export default tseslint.config(
 	},
 	...tseslint.configs.recommended,
 	...eslintPluginAstro.configs.recommended,
+	...eslintPluginAstro.configs['jsx-a11y-recommended'],
 	{
 		files: ['**/*.astro'],
 		rules: {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"format:check": "prettier --check .",
 		"format": "prettier --write .",
 		"lint": "eslint .",
+		"lint:fix": "eslint . --fix",
 		"typecheck": "astro sync && astro-check",
 		"test": "vitest run",
 		"test:coverage": "vitest run --coverage",
@@ -71,11 +72,12 @@
 		"vitest": "^3.2.7"
 	},
 	"lint-staged": {
-		"*.{astro,js,jsx,ts,tsx,md,mdx,json}": [
+		"*.{astro,js,jsx,mjs,cjs,ts,tsx}": [
+			"eslint --fix",
 			"prettier --write"
 		],
-		"*.{astro,js,jsx,ts,tsx}": [
-			"eslint --fix"
+		"*.{md,mdx,json,yml,yaml,css}": [
+			"prettier --write"
 		]
 	},
 	"packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1"

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -16,6 +16,13 @@ module.exports = {
 			options: {
 				parser: 'astro'
 			}
+		},
+		{
+			files: 'src/content/blog/**/*.md',
+			options: {
+				printWidth: 120,
+				proseWrap: 'always'
+			}
 		}
 	]
 }

--- a/src/content/blog/calanyze.md
+++ b/src/content/blog/calanyze.md
@@ -10,7 +10,14 @@ tags: ['Projects', 'Calanyze']
 
 ## Was ist Calanyze?
 
-_Calanyze_ ist eine neue Kalender-App, die sich von bisherigen Kalendern abhebt. Unsere App wird sowohl den gregorianischen Kalender als auch den chinesischen Lunisolarkalender unterstützen. Als Basis dient zunächst der gregorianische Kalender; weitere Kalendersysteme möchten wir später als Erweiterungen integrieren. Um möglichst viele Plattformen zu unterstützen, setzen wir bei der Entwicklung auf Flutter. Das wichtigste Alleinstellungsmerkmal von Calanyze ist die Terminerinnerung nach dem Lunisolarkalender. So können zum Beispiel chinesische Geburtstage zuverlässig nach dem chinesischen Kalender verfolgt werden – und trotzdem bleibt der gewohnte gregorianische Kalender nutzbar. Um die bestmöglichste Erfahrung zu bieten, wird unser Installationsassistent, den Nutztern bei der Installation helfen und den Kalender genau auf Ihre Bedürfnisse anpassen.
+_Calanyze_ ist eine neue Kalender-App, die sich von bisherigen Kalendern abhebt. Unsere App wird sowohl den
+gregorianischen Kalender als auch den chinesischen Lunisolarkalender unterstützen. Als Basis dient zunächst der
+gregorianische Kalender; weitere Kalendersysteme möchten wir später als Erweiterungen integrieren. Um möglichst viele
+Plattformen zu unterstützen, setzen wir bei der Entwicklung auf Flutter. Das wichtigste Alleinstellungsmerkmal von
+Calanyze ist die Terminerinnerung nach dem Lunisolarkalender. So können zum Beispiel chinesische Geburtstage zuverlässig
+nach dem chinesischen Kalender verfolgt werden – und trotzdem bleibt der gewohnte gregorianische Kalender nutzbar Um die
+bestmöglichste Erfahrung zu bieten, wird unser Installationsassistent, den Nutztern bei der Installation helfen und den
+Kalender genau auf Ihre Bedürfnisse anpassen.
 
 ### Features
 

--- a/src/content/blog/en/calanyze.md
+++ b/src/content/blog/en/calanyze.md
@@ -10,7 +10,13 @@ tags: ['Projects', 'Calanyze']
 
 ## What is Calanyze?
 
-_Calanyze_ is a new calendar app that stands out from existing calendars. Our app will support both the Gregorian calendar and the Chinese lunisolar calendar. The Gregorian calendar will serve as the foundation initially; we plan to integrate additional calendar systems as extensions later on. To support as many platforms as possible, we are using Flutter for development. Calanyze’s key unique selling point is its appointment reminders based on the lunisolar calendar. This allows users, for example, to reliably track Chinese birthdays according to the Chinese calendar—while still being able to use the familiar Gregorian calendar. To provide the best possible experience, our setup wizard will guide users through the installation process and customize the calendar precisely to their needs.
+_Calanyze_ is a new calendar app that stands out from existing calendars. Our app will support both the Gregorian
+calendar and the Chinese lunisolar calendar. The Gregorian calendar will serve as the foundation initially; we plan to
+integrate additional calendar systems as extensions later on. To support as many platforms as possible, we are using
+Flutter for development. Calanyze’s key unique selling point is its appointment reminders based on the lunisolar
+calendar. This allows users, for example, to reliably track Chinese birthdays according to the Chinese calendar—while
+still being able to use the familiar Gregorian calendar. To provide the best possible experience, our setup wizard will
+guide users through the installation process and customize the calendar precisely to their needs.
 
 ### Features
 

--- a/src/content/blog/en/facepackguide.md
+++ b/src/content/blog/en/facepackguide.md
@@ -8,24 +8,34 @@ category: 'Football Manager'
 tags: ['FM24', 'Guide']
 ---
 
-Face packs are a great way to enhance your Football Manager 2024 experience by adding real-life images of players, staff, and other in-game characters. However, installing them can sometimes be a bit tricky. If you're having trouble getting your face pack to work, this guide will walk you through the installation process and help troubleshoot common issues.
+Face packs are a great way to enhance your Football Manager 2024 experience by adding real-life images of players,
+staff, and other in-game characters. However, installing them can sometimes be a bit tricky. If you're having trouble
+getting your face pack to work, this guide will walk you through the installation process and help troubleshoot common
+issues.
 
 ## How to install a face pack
 
 Installing a face pack is straightforward if you follow these steps:
 
 1. Download the face pack – Find a reliable source and download the zip file containing the face pack.
-2. Backup old files – Before making changes, consider backing up your existing face pack files in case you want to revert later.
-3. Extract the files – Unzip the downloaded file and move its contents to your graphics folder. The default location on Windows is:
+2. Backup old files – Before making changes, consider backing up your existing face pack files in case you want to
+   revert later.
+3. Extract the files – Unzip the downloaded file and move its contents to your graphics folder. The default location on
+   Windows is:
 
    _C:\Documents\Sports Interactive\Football Manager 2024\graphics_
-   ![Screenshot](../../../assets/images/FootballManager/fpguide2.jpg)
-   If the folder doesn’t exist, create it manually. Make sure you actually have only one folder containing a face pack.
-   If the downloaded face pack doesn’t come with a folder, you need to create one. Name it "facepack," for example, and extract the PNGs and the config.xml into it. Ensure this folder is inside the graphics folder.
-   I don’t recommend loading multiple face packs at the same time. If you wish to combine them, there is a guide further below. ![Screenshot](../../../assets/images/FootballManager/fpguide1.png)
+   ![Screenshot](../../../assets/images/FootballManager/fpguide2.jpg) If the folder doesn’t exist, create it manually.
+   Make sure you actually have only one folder containing a face pack. If the downloaded face pack doesn’t come with a
+   folder, you need to create one. Name it "facepack," for example, and extract the PNGs and the config.xml into it.
+   Ensure this folder is inside the graphics folder. I don’t recommend loading multiple face packs at the same time. If
+   you wish to combine them, there is a guide further below.
+   ![Screenshot](../../../assets/images/FootballManager/fpguide1.png)
 
-4. Managing existing face packs – If you already have a different face pack installed, you may need to overwrite the existing PNG files. However, do not overwrite the config.xml file unless necessary.
-5. Reload the skin in FM – Open Football Manager, go to Preferences > Interface, and reload the skin. Make sure caching is disabled and "Reload skin when confirming changes" is enabled. ![Screenshot](../../../assets/images/FootballManager/stadiumguide11.png)
+4. Managing existing face packs – If you already have a different face pack installed, you may need to overwrite the
+   existing PNG files. However, do not overwrite the config.xml file unless necessary.
+5. Reload the skin in FM – Open Football Manager, go to Preferences > Interface, and reload the skin. Make sure caching
+   is disabled and "Reload skin when confirming changes" is enabled.
+   ![Screenshot](../../../assets/images/FootballManager/stadiumguide11.png)
 6. Ensure all content is there – The folder you have created should only contain PNGs and a config.xml. Nothing else.
 
 ## Common issues and how to fix them
@@ -38,28 +48,47 @@ Installing a face pack is straightforward if you follow these steps:
 - - Enable ID display in the game settings. ![Screenshot](../../../assets/images/FootballManager/stadiumguide7.png)
 - - Click on a player and note the ID in the corner.
 - - Compare it to the PNG file name in your graphics folder.
-- Rename PNG files – If the IDs don’t match, rename the PNG files to match the player’s ID and update config.xml accordingly.
+- Rename PNG files – If the IDs don’t match, rename the PNG files to match the player’s ID and update config.xml
+  accordingly.
 
 ### conflict with another dataset
 
-A custom dataset will create IDs for the players it adds. If you are using multiple datasets, they may assign different IDs to players, than originally intented by the creator. In this case, you may need to prioritize which dataset you want to use by renaming files or adjusting the config.xml file. If you really want to put in the work, follow these steps to combine them. Please read everything here first before actually starting, especially the Tip section.
+A custom dataset will create IDs for the players it adds. If you are using multiple datasets, they may assign different
+IDs to players, than originally intented by the creator. In this case, you may need to prioritize which dataset you want
+to use by renaming files or adjusting the config.xml file. If you really want to put in the work, follow these steps to
+combine them. Please read everything here first before actually starting, especially the Tip section.
 
 - Create a folder for every dataset – Extract the PNGs for each dataset into separate folders.
 - Start a new game – Select the datasets you want to use and start a new game.
 - Check the player IDs in-game – You have to manually figure out their loaded IDs.
 - Rename the PNGs – Rename them to their correct IDs.
-- Edit the config.xml – You have to edit the config.xml and add the correct IDs accordingly. You only need one config.xml, multiple are possible, if you have multiple face packs in multiple folders. Make sure they don't overwrite each other.
-- Combine the face packs – Merge the PNGs of all folders into one. Ensure they have no overlapping IDs. If they do, you will have to delete the PNG you might want to keep along with the associated player. You don't have to do this, but it's the fastest way to find conflicts.
+- Edit the config.xml – You have to edit the config.xml and add the correct IDs accordingly. You only need one
+  config.xml, multiple are possible, if you have multiple face packs in multiple folders. Make sure they don't overwrite
+  each other.
+- Combine the face packs – Merge the PNGs of all folders into one. Ensure they have no overlapping IDs. If they do, you
+  will have to delete the PNG you might want to keep along with the associated player. You don't have to do this, but
+  it's the fastest way to find conflicts.
 
 ## Tips for combining face packs
 
 Here are some helpful tips, to make the whole process more efficient.
 
-- Prioritize the dataset - The datasets load in a specific order, from top to bottom. That means, that the first loaded dataset, will claim the unique IDs for its players. To ensure a dataset loads first, you can rename the .fmf file with a (1) for example at the beginning, but you need to use the **pre-game-editor** for this. **Do not rename the file in the folder** This will have no effect. Some creators might offer you a different dataset file, if you are playing a custom dataset, with a different name fort this particular problem. This makes sense, if you want to combine a bigger and a tinier dataset which each other, so you can make sure, the tinier dataset will be loaded after. That means, you have to rename less players.
-- The IDs will keep their position and have a pattern – For example, if you have 2 datasets. The first one adds 50 players and their IDs are 1-50 and the second dataset includes 10 players with their ID 1-10. You would have 10 conflicts. But because you know which dataset is loaded first, you can assume, the IDs for the second dataset is now 51-60. Make sure, that there are no missing PNGs in either of the face packs and also check at least the first and last unique ID for the both datasets, so you can apply the pattern.
+- Prioritize the dataset - The datasets load in a specific order, from top to bottom. That means, that the first loaded
+  dataset, will claim the unique IDs for its players. To ensure a dataset loads first, you can rename the .fmf file with
+  a (1) for example at the beginning, but you need to use the **pre-game-editor** for this. **Do not rename the file in
+  the folder** This will have no effect. Some creators might offer you a different dataset file, if you are playing a
+  custom dataset, with a different name fort this particular problem. This makes sense, if you want to combine a bigger
+  and a tinier dataset which each other, so you can make sure, the tinier dataset will be loaded after. That means, you
+  have to rename less players.
+- The IDs will keep their position and have a pattern – For example, if you have 2 datasets. The first one adds 50
+  players and their IDs are 1-50 and the second dataset includes 10 players with their ID 1-10. You would have 10
+  conflicts. But because you know which dataset is loaded first, you can assume, the IDs for the second dataset is now
+  51-60. Make sure, that there are no missing PNGs in either of the face packs and also check at least the first and
+  last unique ID for the both datasets, so you can apply the pattern.
 - Use fmXML for creating a new config. It’s really straight forward. Just make sure, your PNGs have the correct names.
 
 ## Final thoughts
 
-Face packs can add a new level of immersion to your Football Manager experience, but setting them up correctly requires attention to detail. By following these steps and troubleshooting common issues, you can enjoy a fully customized game with the faces of your favorite players.
-Happy managing!
+Face packs can add a new level of immersion to your Football Manager experience, but setting them up correctly requires
+attention to detail. By following these steps and troubleshooting common issues, you can enjoy a fully customized game
+with the faces of your favorite players. Happy managing!

--- a/src/content/blog/en/fmmatchlab.md
+++ b/src/content/blog/en/fmmatchlab.md
@@ -10,14 +10,35 @@ tags: ['FM24', 'Projects', 'FM Match Lab']
 
 ## What is FM Match Lab?
 
-At _FM Match Lab_, we are a team of passionate Football Manager fans united by our love for the game. FM Match Lab is a modding project dedicated to improving Football Manager. We believe our work takes the gaming experience to a whole new level. Our journey began with frustration over the cancellation of FM25, the limitations of the current game, and the untapped potential of Football Manager. When we discovered the tools to modify the match engine, we finally saw an opportunity. We formed a team and began working toward our goal. While we take pride in enhancing the gaming experience, it is important to clearly define the limits of our work. Our work involves understanding all the parameters related to the modification of the physical values of various in-game actions. In doing so, we ensure that our understanding of the file and its numerous parameters aligns with what we see on screen. We then adjust each parameter while simultaneously ensuring that other parameters are adjusted to guarantee a smooth and balanced experience. The core calculations of the match engine, decision-making algorithms, and the underlying code that determines match outcomes remain unchanged, as these systems are controlled exclusively by Sports Interactive. Our mission is to work within these parameters to deliver the most realistic and entertaining visual experience possible.
+At _FM Match Lab_, we are a team of passionate Football Manager fans united by our love for the game. FM Match Lab is a
+modding project dedicated to improving Football Manager. We believe our work takes the gaming experience to a whole new
+level. Our journey began with frustration over the cancellation of FM25, the limitations of the current game, and the
+untapped potential of Football Manager. When we discovered the tools to modify the match engine, we finally saw an
+opportunity. We formed a team and began working toward our goal. While we take pride in enhancing the gaming experience,
+it is important to clearly define the limits of our work. Our work involves understanding all the parameters related to
+the modification of the physical values of various in-game actions. In doing so, we ensure that our understanding of the
+file and its numerous parameters aligns with what we see on screen. We then adjust each parameter while simultaneously
+ensuring that other parameters are adjusted to guarantee a smooth and balanced experience. The core calculations of the
+match engine, decision-making algorithms, and the underlying code that determines match outcomes remain unchanged, as
+these systems are controlled exclusively by Sports Interactive. Our mission is to work within these parameters to
+deliver the most realistic and entertaining visual experience possible.
 
 ## My Contribution to FM Match Lab
 
-An important part of my job is looking after our community. To this end, I set up our Discord server and ensure that communication between our team and users runs smoothly. In addition to managing the server, I also maintain regular contact with various content creators to gather feedback and foster collaborations. At the same time, I provide support to our users via Discord, answering questions and helping with issues so that everyone has an optimal gaming experience.
-Another focus of my work is writing content for our website and other channels. In doing so, I make sure to convey our vision and progress clearly and engagingly.
-To ensure the quality of our mods, I also conduct extensive testing and analyze the results to identify potential improvements and detect issues. I also had the honor of being interviewed by [Kicker](https://www.kicker.de/immersiver-spannender-besser-so-will-fm-tweak-den-fm24-veraendern-1109356/artikel) for _FM Match Lab_, formerly known as _FM Tweak_.
+An important part of my job is looking after our community. To this end, I set up our Discord server and ensure that
+communication between our team and users runs smoothly. In addition to managing the server, I also maintain regular
+contact with various content creators to gather feedback and foster collaborations. At the same time, I provide support
+to our users via Discord, answering questions and helping with issues so that everyone has an optimal gaming experience.
+Another focus of my work is writing content for our website and other channels. In doing so, I make sure to convey our
+vision and progress clearly and engagingly. To ensure the quality of our mods, I also conduct extensive testing and
+analyze the results to identify potential improvements and detect issues. I also had the honor of being interviewed by
+[Kicker](https://www.kicker.de/immersiver-spannender-besser-so-will-fm-tweak-den-fm24-veraendern-1109356/artikel) for
+_FM Match Lab_, formerly known as _FM Tweak_.
 
 ## What does the future hold?
 
-Improving the match engine is just the beginning. A current focus is on the training system—because, as many players know, it doesn’t work the way _Sports Interactive_ actually intended. We’ve already developed a solution and created a file that fixes these issues. But our work doesn’t stop there. We are convinced that even without FM25, no one has to miss out on a better Football Manager experience. Our team is constantly working to push the boundaries of what’s possible—always with the goal of creating the best possible gaming experience.
+Improving the match engine is just the beginning. A current focus is on the training system—because, as many players
+know, it doesn’t work the way _Sports Interactive_ actually intended. We’ve already developed a solution and created a
+file that fixes these issues. But our work doesn’t stop there. We are convinced that even without FM25, no one has to
+miss out on a better Football Manager experience. Our team is constantly working to push the boundaries of what’s
+possible—always with the goal of creating the best possible gaming experience.

--- a/src/content/blog/en/logoguidefm24.md
+++ b/src/content/blog/en/logoguidefm24.md
@@ -8,7 +8,9 @@ category: 'Football Manager'
 tags: ['FM24', 'Guide']
 ---
 
-This guide will help you, to install logos for Football Manager 24. Not every logo is licensed in FM24 and this guide will help you to bring more immersion into your game. I will also explain, how to change the config.xml and fixes for problems I have encountered.
+This guide will help you, to install logos for Football Manager 24. Not every logo is licensed in FM24 and this guide
+will help you to bring more immersion into your game. I will also explain, how to change the config.xml and fixes for
+problems I have encountered.
 
 ## How to install
 
@@ -17,30 +19,36 @@ This guide will help you, to install logos for Football Manager 24. Not every lo
 
 _C:\Documents\Sports Interactive\Football Manager 2024\graphics_
 
-It should look similar to this. ![Screenshot](../../../assets/images/FootballManager/fpguide2.jpg)
-If you don't have any graphics folder, you need to create it.
+It should look similar to this. ![Screenshot](../../../assets/images/FootballManager/fpguide2.jpg) If you don't have any
+graphics folder, you need to create it.
 
-3. Unzip the Zip file. You might need 7 Zip for it. It's a free program. Just open the Zip file and move all the content in the graphics folder.
-4. Now we need to load our files:
-   Go in game -> open Preferences -> Interface -> make sure use caching is disabled -> reload ![Screenshot](../../../assets/images/FootballManager/stadiumguide11.png)
+3. Unzip the Zip file. You might need 7 Zip for it. It's a free program. Just open the Zip file and move all the content
+   in the graphics folder.
+4. Now we need to load our files: Go in game -> open Preferences -> Interface -> make sure use caching is disabled ->
+   reload ![Screenshot](../../../assets/images/FootballManager/stadiumguide11.png)
 
 Load up a save and see if it works. If it does, have fun!
 
 ## How to fix problems
 
-If it doesn't work, we might have to do some fine-tuning. That is either, because you have other logos installed, or, because you have other teams loaded, that claim the "unique" ID. If you have other logos installed, you might want to start with [Step 12](#step-12).
+If it doesn't work, we might have to do some fine-tuning. That is either, because you have other logos installed, or,
+because you have other teams loaded, that claim the "unique" ID. If you have other logos installed, you might want to
+start with [Step 12](#step-12).
 
 <a id="step-5"></a>
 
-5. Load up your game and check if the IDs of the teams. I will use Blue Lock from my custom dataset as an example. To do so, Enable Show screen ID in Title Bar. ![Screenshot](../../../assets/images/FootballManager/stadiumguide7.png)
-6. Load up a save and click on the Blue Lock Team. You should now see the ID in the left corner. ![Screenshot](../../../assets/images/FootballManager/logoguide1.jpg)
-7. Open up your graphics folder and compare the IDs of my files with this ID.
-   As you can see, in my case that is correct. The ID in game is the same as the PNG. ![Screenshot](../../../assets/images/FootballManager/logoguide2.jpg)
+5. Load up your game and check if the IDs of the teams. I will use Blue Lock from my custom dataset as an example. To do
+   so, Enable Show screen ID in Title Bar. ![Screenshot](../../../assets/images/FootballManager/stadiumguide7.png)
+6. Load up a save and click on the Blue Lock Team. You should now see the ID in the left corner.
+   ![Screenshot](../../../assets/images/FootballManager/logoguide1.jpg)
+7. Open up your graphics folder and compare the IDs of my files with this ID. As you can see, in my case that is
+   correct. The ID in game is the same as the PNG. ![Screenshot](../../../assets/images/FootballManager/logoguide2.jpg)
 8. If that isn't correct, you have to rename the PNG image, to the ID in game.
 
 <a id="step-9"></a>
 
-9. You also have to open up the config.xml and change the ID name. It is important, to rename the ID twice. I marked both numbers, you have to change in the config.
+9. You also have to open up the config.xml and change the ID name. It is important, to rename the ID twice. I marked
+   both numbers, you have to change in the config.
 
 example config for normal:
 
@@ -69,15 +77,21 @@ example config for small
 ![Screenshot](../../../assets/images/FootballManager/logoguide3.jpg)
 
 10. You also need to do that for both folders. For normal and small. **Make sure to use the correct picture size.**
-11. Now we need to load our files:
-    Go in game -> open Preferences -> Interface -> make sure use caching is disabled -> reload ![Screenshot](../../../assets/images/FootballManager/stadiumguide11.png)
+11. Now we need to load our files: Go in game -> open Preferences -> Interface -> make sure use caching is disabled ->
+    reload ![Screenshot](../../../assets/images/FootballManager/stadiumguide11.png)
 
 <a id="step-12"></a>
 
-12. If it still doesn't work, it might be because of other logos you have installed.
-    Open up the folder, where the other logos are located. If it has a different file structure than mine, try to look for the "clubs" folder. ![Screenshot](../../../assets/images/FootballManager/logoguide4.jpg)
-13. In that folder, you should find the folders small and normal. Open up either of them and place only the PNGs for themy logos and icons in there that you want to replace. Not the config.xml! Repeat now [Step 5](#step-5) to Step 8. You might need to replace certain PNGs, if they share the same ID. Make sure to check the in game ID [Step 5](#step-5) before you replace anything. Also, you should make copies of things, you don't want to lose.
-14. You should now have a folder full of PNGs, with the right IDs and an old config. Copy the config.xml to your desktop, in case you break something. Now you just need to edit the old config.xml. Open it up and change the ID, I have described that in [Step 9](#step-9), to the in game ID and paste it in the list.
+12. If it still doesn't work, it might be because of other logos you have installed. Open up the folder, where the other
+    logos are located. If it has a different file structure than mine, try to look for the "clubs" folder.
+    ![Screenshot](../../../assets/images/FootballManager/logoguide4.jpg)
+13. In that folder, you should find the folders small and normal. Open up either of them and place only the PNGs for
+    themy logos and icons in there that you want to replace. Not the config.xml! Repeat now [Step 5](#step-5) to Step 8.
+    You might need to replace certain PNGs, if they share the same ID. Make sure to check the in game ID
+    [Step 5](#step-5) before you replace anything. Also, you should make copies of things, you don't want to lose.
+14. You should now have a folder full of PNGs, with the right IDs and an old config. Copy the config.xml to your
+    desktop, in case you break something. Now you just need to edit the old config.xml. Open it up and change the ID, I
+    have described that in [Step 9](#step-9), to the in game ID and paste it in the list.
 
 In normal folder:
 
@@ -91,8 +105,9 @@ In small folder:
 <record from="2000339408" to="graphics/pictures/club/2000339408/icon"/>
 ```
 
-Copy this line and change the numbers to the Unique ID of your files. Place it in list.
-Your config.xml will be a lot bigger. But you can put it anywhere in that list. I would recommend putting it on top or bottom of your list, in case you have to change or delete them.
+Copy this line and change the numbers to the Unique ID of your files. Place it in list. Your config.xml will be a lot
+bigger. But you can put it anywhere in that list. I would recommend putting it on top or bottom of your list, in case
+you have to change or delete them.
 
 example config for normal:
 
@@ -106,10 +121,13 @@ example config for normal:
 </record>
 ```
 
-15. You have to do the same process for the small and normal folder. However, it should be fine, to just copy the new lines in your config.xml and change the word logo to icon, or the other way around. Then you just need to place the PNGs and rename them.
-16. Now we need to load our files for the last time:
-    Go in game -> open Preferences -> Interface -> make sure use caching is disabled -> reload ![Screenshot](../../../assets/images/FootballManager/stadiumguide11.png)
+15. You have to do the same process for the small and normal folder. However, it should be fine, to just copy the new
+    lines in your config.xml and change the word logo to icon, or the other way around. Then you just need to place the
+    PNGs and rename them.
+16. Now we need to load our files for the last time: Go in game -> open Preferences -> Interface -> make sure use
+    caching is disabled -> reload ![Screenshot](../../../assets/images/FootballManager/stadiumguide11.png)
 
 ## Final thoughts
 
-That should cover everything. Config.xml managing can be tedious. Make sure not to always use the right IDs and file sizes.
+That should cover everything. Config.xml managing can be tedious. Make sure not to always use the right IDs and file
+sizes.

--- a/src/content/blog/en/scraperino.md
+++ b/src/content/blog/en/scraperino.md
@@ -10,21 +10,26 @@ tags: ['Projects', 'Scraperino']
 
 ## What is Scraperino?
 
-_Scraperino_ is a comprehensive full-stack web application designed to automatically extract (scrape) product data and listings from online marketplaces—specifically _eBay_ (worldwide) and _Kleinanzeigen_.
-The architecture consists of a Python backend (powered by FastAPI and Playwright) and a React frontend (powered by Vite and Node.js).
+_Scraperino_ is a comprehensive full-stack web application designed to automatically extract (scrape) product data and
+listings from online marketplaces—specifically _eBay_ (worldwide) and _Kleinanzeigen_. The architecture consists of a
+Python backend (powered by FastAPI and Playwright) and a React frontend (powered by Vite and Node.js).
 
 ### Features
 
-Users can search for multiple keywords simultaneously, specify exact parameters (such as price ranges or conditions), and the system then extracts all matching listings. Finally, the collected and processed data is provided in a clear Excel file.
+Users can search for multiple keywords simultaneously, specify exact parameters (such as price ranges or conditions),
+and the system then extracts all matching listings. Finally, the collected and processed data is provided in a clear
+Excel file.
 
 - Multi-platform & regional support
 - - Supports Kleinanzeigen (.de)
-- - Supports eBay in numerous international regions (DE, US, UK, AT, CH, FR, IT, ES, etc.), including currency conversion logic
+- - Supports eBay in numerous international regions (DE, US, UK, AT, CH, FR, IT, ES, etc.), including currency
+    conversion logic
 - Detailed Filters & Search Criteria
 - - Price Filter: Minimum and maximum prices can be set
 - - Condition Filter: Limit to New, Used, Refurbished, or Defective/Spare Parts
 - - Listing Formats (eBay): Filter by Auctions, Buy It Now, or Price Suggestions
-- - Listing status (eBay): Search for currently active listings, as well as sold or ended items (useful for price research)
+- - Listing status (eBay): Search for currently active listings, as well as sold or ended items (useful for price
+    research)
 - - Prohibited words (blacklist): Terms appearing in the title result in the item being immediately filtered out
 - Duplicates are filtered out
 - Intelligent anti-bot management & CAPTCHA handling
@@ -34,19 +39,24 @@ Users can search for multiple keywords simultaneously, specify exact parameters 
 
 ### Process
 
-The system uses Playwright with “Stealth” settings to avoid being immediately detected as a bot.
-Live View & Intervention: If the system detects captchas (e.g., DataDome on classifieds sites) or blockages (Akamai or mandatory login on eBay), it does not stop immediately. If the user has enabled “Live View,” the scraper pauses for 5 minutes and alerts the user via the frontend to manually resolve the issue in the browser (e.g., by clicking through a CAPTCHA). Afterward, the script continues running seamlessly.
-Thanks to WebSockets, the React frontend receives real-time updates from the Python backend.
-The user sees a live tracker that shows exactly which page is currently being searched, how many hits were found, how many were filtered out, and how many duplicates were ignored.
-Search queries and platforms are bundled and processed using asynchronous tasks (Asyncio) and parallel browser tabs. The maximum number of concurrent tabs (max_tabs) can be limited to manage system load and IP blocks.
+The system uses Playwright with “Stealth” settings to avoid being immediately detected as a bot. Live View &
+Intervention: If the system detects captchas (e.g., DataDome on classifieds sites) or blockages (Akamai or mandatory
+login on eBay), it does not stop immediately. If the user has enabled “Live View,” the scraper pauses for 5 minutes and
+alerts the user via the frontend to manually resolve the issue in the browser (e.g., by clicking through a CAPTCHA).
+Afterward, the script continues running seamlessly. Thanks to WebSockets, the React frontend receives real-time updates
+from the Python backend. The user sees a live tracker that shows exactly which page is currently being searched, how
+many hits were found, how many were filtered out, and how many duplicates were ignored. Search queries and platforms are
+bundled and processed using asynchronous tasks (Asyncio) and parallel browser tabs. The maximum number of concurrent
+tabs (max_tabs) can be limited to manage system load and IP blocks.
 
-All search results are cleaned up and written to an .xlsx file (Excel) (excel_writer.py).
-The file contains clickable links, preformatted currencies/prices, total costs (price + shipping), and neatly separated columns (title, platform, condition, type, negotiable).
-Automatic deduplication ensures that exactly identical links do not appear multiple times in the Excel spreadsheet.
-Bilingual Support (Localization)
+All search results are cleaned up and written to an .xlsx file (Excel) (excel_writer.py). The file contains clickable
+links, preformatted currencies/prices, total costs (price + shipping), and neatly separated columns (title, platform,
+condition, type, negotiable). Automatic deduplication ensures that exactly identical links do not appear multiple times
+in the Excel spreadsheet. Bilingual Support (Localization)
 
 The application (logs, UI, Excel columns) is fully available in German and English (localization.py).
 
 ### Summary
 
-In summary, Scraperino is a highly advanced, asynchronous web scraper with a focus on robustness (Captcha handling) and user-friendliness (visual interface, real-time feedback, formatted exports).
+In summary, Scraperino is a highly advanced, asynchronous web scraper with a focus on robustness (Captcha handling) and
+user-friendliness (visual interface, real-time feedback, formatted exports).

--- a/src/content/blog/en/stadiumguidefm24.md
+++ b/src/content/blog/en/stadiumguidefm24.md
@@ -8,8 +8,9 @@ category: 'Football Manager'
 tags: ['FM24', 'Guide']
 ---
 
-Have you ever wondered: How you can get your own Stadium Picture in FM24 for your team or even a custom Team? Well, you don’t have to look further. I am here to show you how it’s done! I will use Team Rejects from my Blue Lock Dataset as an example, but it will work for every team.
-Here is an example of how it could look like.
+Have you ever wondered: How you can get your own Stadium Picture in FM24 for your team or even a custom Team? Well, you
+don’t have to look further. I am here to show you how it’s done! I will use Team Rejects from my Blue Lock Dataset as an
+example, but it will work for every team. Here is an example of how it could look like.
 ![Screenshot](../../../assets/images/FootballManager/stadiumguide1.png)
 
 ## Step 1. - Preparation
@@ -24,17 +25,19 @@ Well, that is basically everything.
 
 ## Step 2. – Create a stadium
 
-This step is only important, if you want to create a new stadium. If you just want to replace the picture of an existing stadium, you can skip this.
+This step is only important, if you want to create a new stadium. If you just want to replace the picture of an existing
+stadium, you can skip this.
 
-Start the Pre Game Editor. Load up the dataset you want to edit and go to “Stadiums”. Either you can copy a stadium from here, or you can create a new one. !Screenshot
-Here you can change everything you want about your stadium. Feel free to experiment. The important part in that window is the unique ID. You have to write that down. !Screenshot
+Start the Pre Game Editor. Load up the dataset you want to edit and go to “Stadiums”. Either you can copy a stadium from
+here, or you can create a new one. !Screenshot Here you can change everything you want about your stadium. Feel free to
+experiment. The important part in that window is the unique ID. You have to write that down. !Screenshot
 
 In my case it is 2000342656.
 
-We also have to choose this stadium for the club you want to use.
-So, go to “Clubs” and look for the team. In my case, it is “Rejects”. ![Screenshot ](../../../assets/images/FootballManager/stadiumguide4.png)
-Press Edit and go to Stadium. ![Screenshot](../../../assets/images/FootballManager/stadiumguide5.png) There you have to change the stadium to the one you just created. In my case, it’s Rejects Arena.
-Save the dataset.
+We also have to choose this stadium for the club you want to use. So, go to “Clubs” and look for the team. In my case,
+it is “Rejects”. ![Screenshot ](../../../assets/images/FootballManager/stadiumguide4.png) Press Edit and go to Stadium.
+![Screenshot](../../../assets/images/FootballManager/stadiumguide5.png) There you have to change the stadium to the one
+you just created. In my case, it’s Rejects Arena. Save the dataset.
 ![Screenshot](../../../assets/images/FootballManager/stadiumguide6.png)
 
 ## Step 3. -  File Structure
@@ -46,18 +49,17 @@ What do we need?
 - the .jpg 800 x 480 pixels or tinier
 - the unique ID for the stadium.
 
-Where do we get the unique ID from?
-Either the Pre Game Editor, as I have shown before, or in game , if you enabled “Show unique IDs in header”. !Screenshot !Screenshot
+Where do we get the unique ID from? Either the Pre Game Editor, as I have shown before, or in game , if you enabled
+“Show unique IDs in header”. !Screenshot !Screenshot
 
-Okay, let’s start.
-Go to your graphics folder, if you don’t have one, you need to create it. It’s most likely located in:
-**C:\Documents\Sports Interactive\Football Manager 2024\graphics**
+Okay, let’s start. Go to your graphics folder, if you don’t have one, you need to create it. It’s most likely located
+in: **C:\Documents\Sports Interactive\Football Manager 2024\graphics**
 
 Create a folder. You can call it whatever you want. I would recommend to call it something simple stadiums. !Screenshot
-Open the folder and move the .jpg to it. Rename the .jpg to the unique ID.  In my case it is 2000342656. Your folder should now look similar to this. !Screenshot
+Open the folder and move the .jpg to it. Rename the .jpg to the unique ID.  In my case it is 2000342656. Your folder
+should now look similar to this. !Screenshot
 
-Now create a file and call it _config.xml_.
-Open the file and copy this code in there.
+Now create a file and call it _config.xml_. Open the file and copy this code in there.
 
 ```xml
 <record>
@@ -70,7 +72,8 @@ Open the file and copy this code in there.
 </record>
 ```
 
-Replace **UNIQUE ID** with the correct ID. You can add multiple stadiums at the same time. Delete the 2nd record, if you only want to add a singular stadium. If you have want to add more than 2, just add more lines with the same pattern.
+Replace **UNIQUE ID** with the correct ID. You can add multiple stadiums at the same time. Delete the 2nd record, if you
+only want to add a singular stadium. If you have want to add more than 2, just add more lines with the same pattern.
 
 ![Screenshot](../../../assets/images/FootballManager/stadiumguide12.png)
 
@@ -85,8 +88,9 @@ If you have a custom stadium or a custom team, make sure, to enable the Dataset 
 
 ## Problems
 
-Unfortunately, the 3D Model of the stadium might look not as good as expected, if you create a new stadium. You can't really choose what stadium you want and how it looks like.
-If your stadium has gaps, it means you can upgrade it. So for example:
-My stadium has 100000 seats. I can upgrade it to 200000. That means, that half of your stadium is not build and it will create gaps. Maybe some other setting could also influence this.
+Unfortunately, the 3D Model of the stadium might look not as good as expected, if you create a new stadium. You can't
+really choose what stadium you want and how it looks like. If your stadium has gaps, it means you can upgrade it. So for
+example: My stadium has 100000 seats. I can upgrade it to 200000. That means, that half of your stadium is not build and
+it will create gaps. Maybe some other setting could also influence this.
 
 Now everything should work. Let me know if you encounter any problem! Have a great day and enjoy playing!

--- a/src/content/blog/facepackguide.md
+++ b/src/content/blog/facepackguide.md
@@ -8,58 +8,93 @@ category: 'Football Manager'
 tags: ['FM24', 'Guide']
 ---
 
-Facepacks sind eine großartige Möglichkeit, dein Football Manager 2024 Erlebnis zu verbessern, indem sie echte Bilder von Spielern, Mitarbeitern und anderen Charakteren im Spiel hinzufügen. Die Installation kann jedoch manchmal etwas knifflig sein. Wenn du Probleme hast, dein Facepack zum Laufen zu bringen, wird dich dieser Guide durch den Installationsprozess führen und bei der Behebung häufiger Probleme helfen.
+Facepacks sind eine großartige Möglichkeit, dein Football Manager 2024 Erlebnis zu verbessern, indem sie echte Bilder
+von Spielern, Mitarbeitern und anderen Charakteren im Spiel hinzufügen. Die Installation kann jedoch manchmal etwas
+knifflig sein. Wenn du Probleme hast, dein Facepack zum Laufen zu bringen, wird dich dieser Guide durch den
+Installationsprozess führen und bei der Behebung häufiger Probleme helfen.
 
 ## Wie man ein Facepack installiert
 
 Die Installation eines Facepacks ist unkompliziert, wenn du diese Schritte befolgst:
 
 1. Lade das Facepack herunter – Suche eine zuverlässige Quelle und lade die Zip-Datei mit dem Facepack herunter.
-2. Sichere alte Dateien – Bevor du Änderungen vornimmst, solltest du deine bestehenden Facepack-Dateien sichern, falls du später wieder zurückwechseln möchtest.
-3. Entpacke die Dateien – Entpacke die heruntergeladene Datei und verschiebe den Inhalt in deinen graphics-Ordner. Der Standardpfad unter Windows ist:
+2. Sichere alte Dateien – Bevor du Änderungen vornimmst, solltest du deine bestehenden Facepack-Dateien sichern, falls
+   du später wieder zurückwechseln möchtest.
+3. Entpacke die Dateien – Entpacke die heruntergeladene Datei und verschiebe den Inhalt in deinen graphics-Ordner. Der
+   Standardpfad unter Windows ist:
 
    _C:\Dokumente\Sports Interactive\Football Manager 2024\graphics_
-   ![Screenshot](../../assets/images/FootballManager/fpguide2.jpg)
-   Wenn der Ordner nicht existiert, erstelle ihn manuell. Achte darauf, dass du tatsächlich nur einen Ordner hast, der ein Facepack enthält.
-   Wenn das heruntergeladene Facepack keinen Ordner enthält, musst du einen erstellen. Nenne ihn zum Beispiel "facepack" und entpacke die PNGs sowie die config.xml dort hinein. Stelle sicher, dass sich dieser Ordner innerhalb des graphics-Ordners befindet.
-   Ich empfehle nicht, mehrere Facepacks gleichzeitig zu laden. Wenn du sie kombinieren möchtest, gibt es weiter unten einen Guide dafür. ![Screenshot](../../assets/images/FootballManager/fpguide1.png)
+   ![Screenshot](../../assets/images/FootballManager/fpguide2.jpg) Wenn der Ordner nicht existiert, erstelle ihn
+   manuell. Achte darauf, dass du tatsächlich nur einen Ordner hast, der ein Facepack enthält. Wenn das heruntergeladene
+   Facepack keinen Ordner enthält, musst du einen erstellen. Nenne ihn zum Beispiel "facepack" und entpacke die PNGs
+   sowie die config.xml dort hinein. Stelle sicher, dass sich dieser Ordner innerhalb des graphics-Ordners befindet. Ich
+   empfehle nicht, mehrere Facepacks gleichzeitig zu laden. Wenn du sie kombinieren möchtest, gibt es weiter unten einen
+   Guide dafür. ![Screenshot](../../assets/images/FootballManager/fpguide1.png)
 
-4. Umgang mit bestehenden Facepacks – Wenn du bereits ein anderes Facepack installiert hast, musst du möglicherweise die vorhandenen PNG-Dateien überschreiben. Überschreibe jedoch nicht die config.xml, es sei denn, es ist notwendig.
-5. Lade den Skin im FM neu – Öffne den Football Manager, gehe zu Einstellungen > Interface und lade den Skin neu. Stelle sicher, dass der Cache deaktiviert ist und "Skin neu laden, wenn Änderungen bestätigt werden" aktiviert ist. ![Screenshot](../../assets/images/FootballManager/stadiumguide11.png)
-6. Stelle sicher, dass alles vorhanden ist – Der Ordner, den du erstellt hast, sollte nur PNGs und eine config.xml enthalten. Nichts anderes.
+4. Umgang mit bestehenden Facepacks – Wenn du bereits ein anderes Facepack installiert hast, musst du möglicherweise die
+   vorhandenen PNG-Dateien überschreiben. Überschreibe jedoch nicht die config.xml, es sei denn, es ist notwendig.
+5. Lade den Skin im FM neu – Öffne den Football Manager, gehe zu Einstellungen > Interface und lade den Skin neu. Stelle
+   sicher, dass der Cache deaktiviert ist und "Skin neu laden, wenn Änderungen bestätigt werden" aktiviert ist.
+   ![Screenshot](../../assets/images/FootballManager/stadiumguide11.png)
+6. Stelle sicher, dass alles vorhanden ist – Der Ordner, den du erstellt hast, sollte nur PNGs und eine config.xml
+   enthalten. Nichts anderes.
 
 ## Häufige Probleme und deren Lösungen
 
 ### Meine Spieler haben kein Gesicht
 
-- Probleme mit der Bildgröße - Stelle sicher, dass die PNG-Dateien 250x250 Pixel groß sind, um die beste Anzeigequalität zu gewährleisten.
+- Probleme mit der Bildgröße - Stelle sicher, dass die PNG-Dateien 250x250 Pixel groß sind, um die beste Anzeigequalität
+  zu gewährleisten.
 - Fehlende PNGs - Einige Facepacks enthalten möglicherweise nicht jeden Spieler, was zu leeren Stellen führt.
 - Überprüfe die Spieler-IDs – Jeder Spieler hat eine einzigartige ID im Spiel. Um die richtige ID zu überprüfen:
-- - Aktiviere die ID-Anzeige in den Spieleinstellungen. ![Screenshot](../../assets/images/FootballManager/stadiumguide7.png)
+- - Aktiviere die ID-Anzeige in den Spieleinstellungen.
+    ![Screenshot](../../assets/images/FootballManager/stadiumguide7.png)
 - - Klicke auf einen Spieler und notiere die ID in der Ecke.
 - - Vergleiche sie mit dem Dateinamen des PNGs in deinem graphics-Ordner.
-- PNG-Dateien umbenennen – Wenn die IDs nicht übereinstimmen, benenne die PNG-Dateien so um, dass sie der Spieler-ID entsprechen, und aktualisiere die config.xml entsprechend.
+- PNG-Dateien umbenennen – Wenn die IDs nicht übereinstimmen, benenne die PNG-Dateien so um, dass sie der Spieler-ID
+  entsprechen, und aktualisiere die config.xml entsprechend.
 
 ### Konflikte mit einem anderen Datensatz
 
-Ein benutzerdefinierter Datensatz erstellt IDs für die Spieler, die er hinzufügt. Wenn du mehrere Datensätze verwendest, können diese den Spielern andere IDs zuweisen, als vom Ersteller ursprünglich vorgesehen. In diesem Fall musst du möglicherweise priorisieren, welchen Datensatz du verwenden möchtest, indem du Dateien umbenennst oder die config.xml anpasst. Wenn du dir wirklich die Arbeit machen möchtest, befolge diese Schritte, um sie zu kombinieren. Bitte lies zuerst alles hier durch, bevor du anfängst, insbesondere den Abschnitt "Tipps".
+Ein benutzerdefinierter Datensatz erstellt IDs für die Spieler, die er hinzufügt. Wenn du mehrere Datensätze verwendest,
+können diese den Spielern andere IDs zuweisen, als vom Ersteller ursprünglich vorgesehen. In diesem Fall musst du
+möglicherweise priorisieren, welchen Datensatz du verwenden möchtest, indem du Dateien umbenennst oder die config.xml
+anpasst. Wenn du dir wirklich die Arbeit machen möchtest, befolge diese Schritte, um sie zu kombinieren. Bitte lies
+zuerst alles hier durch, bevor du anfängst, insbesondere den Abschnitt "Tipps".
 
 - Erstelle einen Ordner für jeden Datensatz – Entpacke die PNGs für jeden Datensatz in separate Ordner.
 - Starte ein neues Spiel – Wähle die Datensätze aus, die du verwenden möchtest, und starte ein neues Spiel.
 - Überprüfe die Spieler-IDs im Spiel – Du musst ihre geladenen IDs manuell herausfinden.
 - Benenne die PNGs um – Benenne sie in ihre korrekten IDs um.
-- Bearbeite die config.xml – Du musst die config.xml bearbeiten und die richtigen IDs entsprechend hinzufügen. Du benötigst nur eine config.xml. Mehrere sind möglich, wenn du mehrere Facepacks in mehreren Ordnern hast. Stelle nur sicher, dass sie sich nicht gegenseitig überschreiben.
-- Kombiniere die Facepacks – Führe die PNGs aller Ordner zu einem zusammen. Stelle sicher, dass es keine überschneidenden IDs gibt. Wenn doch, musst du das PNG, das du behalten möchtest, zusammen mit dem zugehörigen Spieler löschen. Du musst das nicht tun, aber es ist der schnellste Weg, um Konflikte zu finden.
+- Bearbeite die config.xml – Du musst die config.xml bearbeiten und die richtigen IDs entsprechend hinzufügen. Du
+  benötigst nur eine config.xml. Mehrere sind möglich, wenn du mehrere Facepacks in mehreren Ordnern hast. Stelle nur
+  sicher, dass sie sich nicht gegenseitig überschreiben.
+- Kombiniere die Facepacks – Führe die PNGs aller Ordner zu einem zusammen. Stelle sicher, dass es keine
+  überschneidenden IDs gibt. Wenn doch, musst du das PNG, das du behalten möchtest, zusammen mit dem zugehörigen Spieler
+  löschen. Du musst das nicht tun, aber es ist der schnellste Weg, um Konflikte zu finden.
 
 ## Tipps zum Kombinieren von Facepacks
 
 Hier sind einige hilfreiche Tipps, um den gesamten Prozess effizienter zu gestalten:
 
-- Priorisiere den Datensatz - Die Datensätze laden in einer bestimmten Reihenfolge, von oben nach unten. Das bedeutet, dass der zuerst geladene Datensatz die eindeutigen IDs für seine Spieler beansprucht. Um sicherzustellen, dass ein Datensatz zuerst lädt, kannst du die .fmf-Datei umbenennen (z. B. mit einer (1) am Anfang). Dafür musst du jedoch den **Pre-Game Editor** verwenden. **Benenne die Datei nicht einfach im Ordner um**, das hat keinen Effekt. Einige Ersteller bieten dir vielleicht eine alternative Datensatz-Datei mit einem anderen Namen an, speziell für dieses Problem. Dies ist sinnvoll, wenn du einen größeren und einen kleineren Datensatz miteinander kombinieren möchtest, sodass du sicherstellen kannst, dass der kleinere Datensatz danach geladen wird. Das bedeutet, dass du weniger Spieler umbenennen musst.
-- Die IDs behalten ihre Position und haben ein Muster – Zum Beispiel: Wenn du 2 Datensätze hast. Der erste fügt 50 Spieler hinzu und ihre IDs sind 1-50. Der zweite Datensatz enthält 10 Spieler mit den IDs 1-10. Du hättest 10 Konflikte. Aber da du weißt, welcher Datensatz zuerst geladen wird, kannst du davon ausgehen, dass die IDs für den zweiten Datensatz jetzt 51-60 sind. Stelle sicher, dass in keinem der Facepacks PNGs fehlen, und überprüfe zumindest die erste und letzte eindeutige ID für beide Datensätze, damit du das Muster anwenden kannst.
-- Nutze fmXML, um eine neue config zu erstellen. Es ist wirklich unkompliziert. Stelle nur sicher, dass deine PNGs die richtigen Namen haben.
+- Priorisiere den Datensatz - Die Datensätze laden in einer bestimmten Reihenfolge, von oben nach unten. Das bedeutet,
+  dass der zuerst geladene Datensatz die eindeutigen IDs für seine Spieler beansprucht. Um sicherzustellen, dass ein
+  Datensatz zuerst lädt, kannst du die .fmf-Datei umbenennen (z. B. mit einer (1) am Anfang). Dafür musst du jedoch den
+  **Pre-Game Editor** verwenden. **Benenne die Datei nicht einfach im Ordner um**, das hat keinen Effekt. Einige
+  Ersteller bieten dir vielleicht eine alternative Datensatz-Datei mit einem anderen Namen an, speziell für dieses
+  Problem. Dies ist sinnvoll, wenn du einen größeren und einen kleineren Datensatz miteinander kombinieren möchtest,
+  sodass du sicherstellen kannst, dass der kleinere Datensatz danach geladen wird. Das bedeutet, dass du weniger Spieler
+  umbenennen musst.
+- Die IDs behalten ihre Position und haben ein Muster – Zum Beispiel: Wenn du 2 Datensätze hast. Der erste fügt 50
+  Spieler hinzu und ihre IDs sind 1-50. Der zweite Datensatz enthält 10 Spieler mit den IDs 1-10. Du hättest 10
+  Konflikte. Aber da du weißt, welcher Datensatz zuerst geladen wird, kannst du davon ausgehen, dass die IDs für den
+  zweiten Datensatz jetzt 51-60 sind. Stelle sicher, dass in keinem der Facepacks PNGs fehlen, und überprüfe zumindest
+  die erste und letzte eindeutige ID für beide Datensätze, damit du das Muster anwenden kannst.
+- Nutze fmXML, um eine neue config zu erstellen. Es ist wirklich unkompliziert. Stelle nur sicher, dass deine PNGs die
+  richtigen Namen haben.
 
 ## Abschließende Gedanken
 
-Facepacks können deinem Football Manager-Erlebnis eine neue Stufe der Immersion verleihen, aber ihre korrekte Einrichtung erfordert etwas Liebe zum Detail. Wenn du diese Schritte befolgst und häufige Probleme behebst, kannst du ein vollständig angepasstes Spiel mit den Gesichtern deiner Lieblingsspieler genießen.
-Viel Spaß beim Managen!
+Facepacks können deinem Football Manager-Erlebnis eine neue Stufe der Immersion verleihen, aber ihre korrekte
+Einrichtung erfordert etwas Liebe zum Detail. Wenn du diese Schritte befolgst und häufige Probleme behebst, kannst du
+ein vollständig angepasstes Spiel mit den Gesichtern deiner Lieblingsspieler genießen. Viel Spaß beim Managen!

--- a/src/content/blog/fmmatchlab.md
+++ b/src/content/blog/fmmatchlab.md
@@ -10,15 +10,40 @@ tags: ['FM24', 'Projects', 'FM Match Lab']
 
 ## Was ist FM Match Lab?
 
-Bei _FM Match Lab_ sind wir ein Team leidenschaftlicher Football Manager-Fans, die durch ihre Liebe zum Spiel vereint sind. FM Match Lab ist ein Modding-Projekt, das sich der Verbesserung von Football Manager verschrieben hat. Wir sind überzeugt, dass unsere Arbeit das Spielerlebnis auf ein neues Niveau hebt. Unsere Reise begann mit der Frustration über die Cancellation von FM25, die Einschränkungen des aktuellen Spiels und das nicht ausgeschöpfte Potenzial des Football Managers. Als die Tools entdeckt wurden, um die Match Engine zu modifizieren, sahen wir endlich eine Chance. Wir gründeten ein Team und begannen, an unserem Ziel zu arbeiten. Auch wenn wir stolz darauf sind, das Spielerlebnis zu verbessern, ist es wichtig, die Grenzen unserer Arbeit klar zu definieren. Unsere Arbeit besteht darin, alle Parameter zu verstehen, die mit der Veränderung der physikalischen Werte verschiedener Spielaktionen zusammenhängen. Dabei stellen wir sicher, dass unser Verständnis der Datei und ihrer zahlreichen Parameter mit dem übereinstimmt, was wir auf dem Bildschirm sehen. Anschließend passen wir jeden Parameter an und sorgen gleichzeitig dafür, dass weitere Parameter angepasst werden, um ein flüssiges und ausgewogenes Erlebnis zu gewährleisten. Die grundlegenden Berechnungen der Match Engine, Entscheidungsalgorithmen und der zugrunde liegende Code, der die Spielausgänge bestimmt, bleiben unberührt, da diese Systeme ausschließlich von Sports Interactive kontrolliert werden. Unsere Mission ist es, innerhalb dieser Parameter zu arbeiten, um das realistischste und unterhaltsamste visuelle Erlebnis zu bieten.
+Bei _FM Match Lab_ sind wir ein Team leidenschaftlicher Football Manager-Fans, die durch ihre Liebe zum Spiel vereint
+sind. FM Match Lab ist ein Modding-Projekt, das sich der Verbesserung von Football Manager verschrieben hat. Wir sind
+überzeugt, dass unsere Arbeit das Spielerlebnis auf ein neues Niveau hebt. Unsere Reise begann mit der Frustration über
+die Cancellation von FM25, die Einschränkungen des aktuellen Spiels und das nicht ausgeschöpfte Potenzial des Football
+Managers. Als die Tools entdeckt wurden, um die Match Engine zu modifizieren, sahen wir endlich eine Chance. Wir
+gründeten ein Team und begannen, an unserem Ziel zu arbeiten. Auch wenn wir stolz darauf sind, das Spielerlebnis zu
+verbessern, ist es wichtig, die Grenzen unserer Arbeit klar zu definieren. Unsere Arbeit besteht darin, alle Parameter
+zu verstehen, die mit der Veränderung der physikalischen Werte verschiedener Spielaktionen zusammenhängen. Dabei stellen
+wir sicher, dass unser Verständnis der Datei und ihrer zahlreichen Parameter mit dem übereinstimmt, was wir auf dem
+Bildschirm sehen. Anschließend passen wir jeden Parameter an und sorgen gleichzeitig dafür, dass weitere Parameter
+angepasst werden, um ein flüssiges und ausgewogenes Erlebnis zu gewährleisten. Die grundlegenden Berechnungen der Match
+Engine, Entscheidungsalgorithmen und der zugrunde liegende Code, der die Spielausgänge bestimmt, bleiben unberührt, da
+diese Systeme ausschließlich von Sports Interactive kontrolliert werden. Unsere Mission ist es, innerhalb dieser
+Parameter zu arbeiten, um das realistischste und unterhaltsamste visuelle Erlebnis zu bieten.
 
 ## Mein Beitrag zu FM Match Lab
 
-Ein wichtiger Teil meiner Arbeit ist die Betreuung unserer Community. Dafür habe ich unseren Discord-Server eingerichtet und sorge dafür, dass die Kommunikation zwischen unserem Team und den Nutzern reibungslos funktioniert. Neben der Organisation des Servers stehe ich auch im regelmäßigen Austausch mit verschiedenen Content-Creatorn, um Feedback einzuholen und Kooperationen zu fördern. Gleichzeitig biete ich unseren Nutzern Support über Discord an, beantworte Fragen und helfe bei Problemen, damit alle ein optimales Spielerlebnis haben.
-Ein weiterer Schwerpunkt meiner Tätigkeit liegt im Verfassen von Texten für unsere Website und anderen Kanälen. Dabei achte ich darauf, unsere Vision und Fortschritte klar und ansprechend zu vermitteln.
-Um die Qualität unserer Mods sicherzustellen, führe ich außerdem umfangreiche Tests durch und analysiere die Ergebnisse, um mögliche Optimierungen zu identifizieren und Probleme zu erkennen.
-Außerdem hatte ich die Ehre vom [Kicker](https://www.kicker.de/immersiver-spannender-besser-so-will-fm-tweak-den-fm24-veraendern-1109356/artikel) zu _FM Match Lab_, ehemals _FM Tweak_ interviewt zu werden.
+Ein wichtiger Teil meiner Arbeit ist die Betreuung unserer Community. Dafür habe ich unseren Discord-Server eingerichtet
+und sorge dafür, dass die Kommunikation zwischen unserem Team und den Nutzern reibungslos funktioniert. Neben der
+Organisation des Servers stehe ich auch im regelmäßigen Austausch mit verschiedenen Content-Creatorn, um Feedback
+einzuholen und Kooperationen zu fördern. Gleichzeitig biete ich unseren Nutzern Support über Discord an, beantworte
+Fragen und helfe bei Problemen, damit alle ein optimales Spielerlebnis haben. Ein weiterer Schwerpunkt meiner Tätigkeit
+liegt im Verfassen von Texten für unsere Website und anderen Kanälen. Dabei achte ich darauf, unsere Vision und
+Fortschritte klar und ansprechend zu vermitteln. Um die Qualität unserer Mods sicherzustellen, führe ich außerdem
+umfangreiche Tests durch und analysiere die Ergebnisse, um mögliche Optimierungen zu identifizieren und Probleme zu
+erkennen. Außerdem hatte ich die Ehre vom
+[Kicker](https://www.kicker.de/immersiver-spannender-besser-so-will-fm-tweak-den-fm24-veraendern-1109356/artikel) zu _FM
+Match Lab_, ehemals _FM Tweak_ interviewt zu werden.
 
 ## Was bringt die Zukunft?
 
-Das verbessern der Match Engine ist nur der Anfang. Ein aktueller Fokus liegt auf dem Trainingssystem – denn wie viele Spieler wissen, es funktioniert nicht so, wie es von _Sports Interactive_ eigentlich gedacht war. Hier haben wir bereits eine Lösung entwickelt und eine entsprechende Datei erstellt, die diese Probleme behebt. Doch damit hört unsere Arbeit nicht auf. Wir sind überzeugt: Auch ohne FM25 muss niemand auf ein besseres Football Manager-Erlebnis verzichten. Unser Team arbeitet kontinuierlich daran, die Grenzen des Möglichen auszuloten – immer mit dem Ziel, das bestmögliche Spielerlebnis zu schaffen.
+Das verbessern der Match Engine ist nur der Anfang. Ein aktueller Fokus liegt auf dem Trainingssystem – denn wie viele
+Spieler wissen, es funktioniert nicht so, wie es von _Sports Interactive_ eigentlich gedacht war. Hier haben wir bereits
+eine Lösung entwickelt und eine entsprechende Datei erstellt, die diese Probleme behebt. Doch damit hört unsere Arbeit
+nicht auf. Wir sind überzeugt: Auch ohne FM25 muss niemand auf ein besseres Football Manager-Erlebnis verzichten. Unser
+Team arbeitet kontinuierlich daran, die Grenzen des Möglichen auszuloten – immer mit dem Ziel, das bestmögliche
+Spielerlebnis zu schaffen.

--- a/src/content/blog/fuechse-und-baby-boom.md
+++ b/src/content/blog/fuechse-und-baby-boom.md
@@ -1,6 +1,8 @@
 ---
 title: 'Von Füchsen und Familien: Wenn Bejagungsdruck zu Babyboom führt'
-description: 'Ein vergleichender Blick auf Fortpflanzungsstrategien von Füchsen und Menschen – zwischen Jagddruck, Unsicherheit und Babyboom.'
+description:
+  'Ein vergleichender Blick auf Fortpflanzungsstrategien von Füchsen und Menschen – zwischen Jagddruck, Unsicherheit und
+  Babyboom.'
 pubDate: 'Apr 11 2025'
 heroImage: '../../assets/images/fox.png'
 author: 'Lukas Westholt'
@@ -8,17 +10,25 @@ category: 'Thoughts'
 tags: ['Random']
 ---
 
-In Leipzig leben überraschend viele Füchse – mitten in der Stadt, auf Industriebrachen, in Parkanlagen, unter Gartenlauben. Als Informatiker beobachte ich gern Muster und Systeme. Und das Verhalten dieser Stadtfüchse erinnert mich frappierend an ein ganz anderes Thema: den demografischen Wandel – und den Babyboom in der menschlichen Bevölkerung nach dem 2. Weltkrieg.
+In Leipzig leben überraschend viele Füchse – mitten in der Stadt, auf Industriebrachen, in Parkanlagen, unter
+Gartenlauben. Als Informatiker beobachte ich gern Muster und Systeme. Und das Verhalten dieser Stadtfüchse erinnert mich
+frappierend an ein ganz anderes Thema: den demografischen Wandel – und den Babyboom in der menschlichen Bevölkerung nach
+dem 2. Weltkrieg.
 
 Was haben Füchse mit Babys zu tun? Eine Menge, wenn man sich die Zahlen ansieht.
 
-Biologen haben beobachtet, dass weibliche Füchse auf erhöhten Bejagungsdruck oder Urbanisierungsstress nicht etwa mit Rückzug reagieren – sondern mit vermehrter Fortpflanzung. Es ist ein evolutionärer Reflex: Höhere Sterblichkeit? Dann lieber mehr Nachwuchs! Der Nachwuchs sichert das Überleben der Art.
+Biologen haben beobachtet, dass weibliche Füchse auf erhöhten Bejagungsdruck oder Urbanisierungsstress nicht etwa mit
+Rückzug reagieren – sondern mit vermehrter Fortpflanzung. Es ist ein evolutionärer Reflex: Höhere Sterblichkeit? Dann
+lieber mehr Nachwuchs! Der Nachwuchs sichert das Überleben der Art.
 
 Und was macht der Mensch?
 
-In Deutschland war lange Flaute auf den Geburtenstationen. Doch dann, in den 2000er und 2010er Jahren, kam der sogenannte "Mini-Babyboom". Plötzlich stiegen die Geburtenzahlen leicht. Warum?
+In Deutschland war lange Flaute auf den Geburtenstationen. Doch dann, in den 2000er und 2010er Jahren, kam der
+sogenannte "Mini-Babyboom". Plötzlich stiegen die Geburtenzahlen leicht. Warum?
 
-Nicht wegen Bejagung, klar. Aber vielleicht wegen eines anderen Drucks: steigende Mieten, unsichere Jobs, globale Krisen, Pandemien. Inmitten all dieser Unsicherheit kam bei vielen Paaren offenbar der Gedanke: „Jetzt oder nie!“ – ein psychologischer Impuls, der evolutionär gar nicht so weit vom Fuchs entfernt ist.
+Nicht wegen Bejagung, klar. Aber vielleicht wegen eines anderen Drucks: steigende Mieten, unsichere Jobs, globale
+Krisen, Pandemien. Inmitten all dieser Unsicherheit kam bei vielen Paaren offenbar der Gedanke: „Jetzt oder nie!“ – ein
+psychologischer Impuls, der evolutionär gar nicht so weit vom Fuchs entfernt ist.
 
 ## Ein Systemvergleich aus informatischer Sicht:
 
@@ -27,27 +37,39 @@ Nicht wegen Bejagung, klar. Aber vielleicht wegen eines anderen Drucks: steigend
 | **Füchse (biologisch)** | Bejagungsdruck       | Erhöhte Fruchtbarkeit    |
 | **Menschen (sozial)**   | Zukunftsunsicherheit | Plötzlicher Kinderwunsch |
 
-Beide Systeme zeigen: Unter Druck kann die Reproduktionsrate steigen – als eine Art biologische oder kulturelle Fehlertoleranz. Wenn die Welt unsicher wird, multipliziert man das, was zählt: Nachwuchs, Zukunft, Hoffnung.
+Beide Systeme zeigen: Unter Druck kann die Reproduktionsrate steigen – als eine Art biologische oder kulturelle
+Fehlertoleranz. Wenn die Welt unsicher wird, multipliziert man das, was zählt: Nachwuchs, Zukunft, Hoffnung.
 
 ## Historische Perspektive: Der Babyboom nach dem Zweiten Weltkrieg
 
-Ein besonders eindrückliches Beispiel für diesen Zusammenhang findet sich in der Geschichte: Nach dem Zweiten Weltkrieg kam es in Deutschland (wie auch in vielen anderen Ländern) zu einem massiven Babyboom. Zwischen 1946 und Mitte der 1960er stiegen die Geburtenraten deutlich, trotz oder gerade wegen der extremen Verluste an Menschenleben während des Krieges.
+Ein besonders eindrückliches Beispiel für diesen Zusammenhang findet sich in der Geschichte: Nach dem Zweiten Weltkrieg
+kam es in Deutschland (wie auch in vielen anderen Ländern) zu einem massiven Babyboom. Zwischen 1946 und Mitte der
+1960er stiegen die Geburtenraten deutlich, trotz oder gerade wegen der extremen Verluste an Menschenleben während des
+Krieges.
 
-Allein im Zweiten Weltkrieg starben über 7 Millionen Deutsche, davon viele junge Männer im zeugungsfähigen Alter. Und doch kam es anschließend zu einer reproduktiven Welle, getragen von einem tiefen Wunsch nach Normalität, Zukunft und Neuanfang. Auch hier also: Auf extreme Verluste folgte eine Phase intensiver Reproduktion.
+Allein im Zweiten Weltkrieg starben über 7 Millionen Deutsche, davon viele junge Männer im zeugungsfähigen Alter. Und
+doch kam es anschließend zu einer reproduktiven Welle, getragen von einem tiefen Wunsch nach Normalität, Zukunft und
+Neuanfang. Auch hier also: Auf extreme Verluste folgte eine Phase intensiver Reproduktion.
 
 ## Pattern? In Zeiten des Friedens sinkt die Geburtenrate
 
 Jetzt stellt sich natürlich die Frage, ob dieser Zusammenhang auch in der anderen Richtung gilt.
 
-Die Umkehrung des Musters sagt aus, dass in Zeiten des relativen Friedens, wie wir sie in weiten Teilen Europas heute erleben, die Geburtenzahlen niedrig sind. Man könnte fast sagen: Je sicherer und planbarer das Leben wird, desto seltener entscheidet man sich für Kinder. Kein unmittelbarer Druck, kein existenzieller Zwang – dafür Karriereplanung, Lebensstiloptimierung, Klimaangst und Wohnungsknappheit.
+Die Umkehrung des Musters sagt aus, dass in Zeiten des relativen Friedens, wie wir sie in weiten Teilen Europas heute
+erleben, die Geburtenzahlen niedrig sind. Man könnte fast sagen: Je sicherer und planbarer das Leben wird, desto
+seltener entscheidet man sich für Kinder. Kein unmittelbarer Druck, kein existenzieller Zwang – dafür Karriereplanung,
+Lebensstiloptimierung, Klimaangst und Wohnungsknappheit.
 
 Das evolutionäre „Jetzt oder nie“ verwandelt sich in ein „Vielleicht später – oder gar nicht“.
 
 ---
 
 **Fazit:**  
-Füchse in der Stadt erinnern uns daran, wie Leben auf Unsicherheit reagiert - und dass auch der Mensch manchmal instinktiver handelt, als er denkt.
+Füchse in der Stadt erinnern uns daran, wie Leben auf Unsicherheit reagiert - und dass auch der Mensch manchmal
+instinktiver handelt, als er denkt.
 
-[1] [Sabrina, S. et al. (2009). Pulsed resources and climate-induced variation in the reproductive traits of wild boar under high hunting pressure.](https://doi.org/10.1111/j.1365-2656.2009.01579.x)
+[1]
+[Sabrina, S. et al. (2009). Pulsed resources and climate-induced variation in the reproductive traits of wild boar under high hunting pressure.](https://doi.org/10.1111/j.1365-2656.2009.01579.x)
 
-[2] [Stadt Leipzig: Wildtiere in der Stadt](https://www.leipzig.de/freizeit-kultur-und-tourismus/parks-waelder-und-friedhoefe/stadtwald-und-auenwald/wildtiere-in-der-stadt)
+[2]
+[Stadt Leipzig: Wildtiere in der Stadt](https://www.leipzig.de/freizeit-kultur-und-tourismus/parks-waelder-und-friedhoefe/stadtwald-und-auenwald/wildtiere-in-der-stadt)

--- a/src/content/blog/ki-code-qualitaet-mining-studie.md
+++ b/src/content/blog/ki-code-qualitaet-mining-studie.md
@@ -1,63 +1,54 @@
 ---
 title: 'Macht KI-Assistenz Open-Source-Code messbar schlechter?'
-description: 'Eine Mining-Studie zu GitHub Copilot, Cursor und Claude Code an 571 Repositories, und warum das klarste Ergebnis ein Nullbefund ist.'
+description:
+  'Eine Mining-Studie zu GitHub Copilot, Cursor und Claude Code an 571 Repositories, und warum das klarste Ergebnis ein
+  Nullbefund ist.'
 pubDate: 'Jul 07 2026'
 author: 'Lukas Westholt'
 category: 'Research'
 tags: ['Copilot', 'Code Quality', 'Mining Study', 'Empirical Software Engineering']
 ---
 
-Seit 2022 sind KI-Coding-Assistenten wie GitHub Copilot, Cursor und Claude Code
-fester Teil der Open-Source-Entwicklung. Dass sie schneller machen, ist gut
-belegt. Ob der Code dadurch schlechter (oder besser) wird, ist es nicht. Genau
-diese Lücke habe ich in meiner Seminararbeit an der Universität Leipzig untersucht.
+Seit 2022 sind KI-Coding-Assistenten wie GitHub Copilot, Cursor und Claude Code fester Teil der Open-Source-Entwicklung.
+Dass sie schneller machen, ist gut belegt. Ob der Code dadurch schlechter (oder besser) wird, ist es nicht. Genau diese
+Lücke habe ich in meiner Seminararbeit an der Universität Leipzig untersucht.
 
 ## Der Aufbau
 
-Ich habe 272 Repositories, die nachweislich einen KI-Assistenten eingesetzt
-haben, mit 299 Kontroll-Repositories ohne solches Signal verglichen. Das
-Adoptionssignal stammt aus einer dreistufigen Hierarchie: Konfigurationsdateien
-wie `CLAUDE.md` (stark), KI-Co-Authorship in Commit-Trailern (mittel) und
-Schlüsselwörter in Commit-Nachrichten (schwach, nur als Sensitivitätsanalyse).
-Insgesamt deckt die Hierarchie 17 Assistenten ab.
+Ich habe 272 Repositories, die nachweislich einen KI-Assistenten eingesetzt haben, mit 299 Kontroll-Repositories ohne
+solches Signal verglichen. Das Adoptionssignal stammt aus einer dreistufigen Hierarchie: Konfigurationsdateien wie
+`CLAUDE.md` (stark), KI-Co-Authorship in Commit-Trailern (mittel) und Schlüsselwörter in Commit-Nachrichten (schwach,
+nur als Sensitivitätsanalyse). Insgesamt deckt die Hierarchie 17 Assistenten ab.
 
-Weil jedes Projekt seinen eigenen Adoptionszeitpunkt bekommt, konnte ich pro
-Repository vier Snapshots ziehen (rund ein halbes Jahr vor und nach dem Signal)
-und daraus eine gestaffelte Interrupted Time Series mit Difference-in-Differences
-gegen die Kontrollgruppe rechnen. Pro Snapshot habe ich 15 statische
-Qualitätsmetriken gemessen, von zyklomatischer Komplexität über Lint-Warnungen
-bis zur Testdichte.
+Weil jedes Projekt seinen eigenen Adoptionszeitpunkt bekommt, konnte ich pro Repository vier Snapshots ziehen (rund ein
+halbes Jahr vor und nach dem Signal) und daraus eine gestaffelte Interrupted Time Series mit Difference-in-Differences
+gegen die Kontrollgruppe rechnen. Pro Snapshot habe ich 15 statische Qualitätsmetriken gemessen, von zyklomatischer
+Komplexität über Lint-Warnungen bis zur Testdichte.
 
 ## Das Ergebnis
 
-Für die beiden Kernfragen gibt es keinen nachweisbaren Effekt. Die
-Difference-in-Differences für die durchschnittliche zyklomatische Komplexität
-liegt bei -0,04 (95%-Konfidenzintervall [-0,13, 0,04]), für den Anteil der
-Bugfix-Commits bei 0,03 ([-0,02, 0,09]). Beide Intervalle schließen die Null
-ein, und es gibt keine Variation nach Sprache (Python vs. TypeScript) oder
-Aktivitätsniveau.
+Für die beiden Kernfragen gibt es keinen nachweisbaren Effekt. Die Difference-in-Differences für die durchschnittliche
+zyklomatische Komplexität liegt bei -0,04 (95%-Konfidenzintervall [-0,13, 0,04]), für den Anteil der Bugfix-Commits bei
+0,03 ([-0,02, 0,09]). Beide Intervalle schließen die Null ein, und es gibt keine Variation nach Sprache (Python vs.
+TypeScript) oder Aktivitätsniveau.
 
-Interessanter sind die explorativen Befunde. Adoptierende Projekte testen und
-dokumentieren etwas mehr: Testdichte, Testanzahl und (in Python) die
-Docstring-Abdeckung steigen, die Parameter pro Funktion sinken leicht. Alle
-Effektstärken bleiben aber klein (größtes Cliff's Delta 0,27). Und bei mehreren
-dieser Metriken liefen die beiden Gruppen schon vor der Adoption auseinander. Ich
-lese sie deshalb als hypothesengenerierend, nicht als Beleg.
+Interessanter sind die explorativen Befunde. Adoptierende Projekte testen und dokumentieren etwas mehr: Testdichte,
+Testanzahl und (in Python) die Docstring-Abdeckung steigen, die Parameter pro Funktion sinken leicht. Alle Effektstärken
+bleiben aber klein (größtes Cliff's Delta 0,27). Und bei mehreren dieser Metriken liefen die beiden Gruppen schon vor
+der Adoption auseinander. Ich lese sie deshalb als hypothesengenerierend, nicht als Beleg.
 
-Ein scheinbarer Ausreißer: die maximale Komplexität steigt deutlich. Das ist aber
-eine Ordnungsstatistik, die mit der Codebasis mitwächst. Der normalisierte Anteil
-komplexer Funktionen bleibt unverändert, also steckt dahinter Wachstum, keine
-echte Verkomplizierung.
+Ein scheinbarer Ausreißer: die maximale Komplexität steigt deutlich. Das ist aber eine Ordnungsstatistik, die mit der
+Codebasis mitwächst. Der normalisierte Anteil komplexer Funktionen bleibt unverändert, also steckt dahinter Wachstum,
+keine echte Verkomplizierung.
 
 ## Was ich mitnehme
 
-KI-Assistenz macht Open-Source-Code in den messbaren statischen Metriken weder
-klar besser noch schlechter. Das ist ein unspektakuläres, aber ehrliches
-Ergebnis. Die größte Schwäche bleibt die unscharfe Behandlungsgrenze: Ich messe,
-ab wann ein Projekt KI-Nutzung sichtbar macht, nicht ab wann es sie wirklich
-nutzt. Der nächste Schritt wäre, von der Projektebene auf die einzelnen
-KI-zugeschriebenen Änderungen herunterzugehen.
+KI-Assistenz macht Open-Source-Code in den messbaren statischen Metriken weder klar besser noch schlechter. Das ist ein
+unspektakuläres, aber ehrliches Ergebnis. Die größte Schwäche bleibt die unscharfe Behandlungsgrenze: Ich messe, ab wann
+ein Projekt KI-Nutzung sichtbar macht, nicht ab wann es sie wirklich nutzt. Der nächste Schritt wäre, von der
+Projektebene auf die einzelnen KI-zugeschriebenen Änderungen herunterzugehen.
 
 ---
 
-Die vollständige Seminararbeit gibt es hier als PDF: [Westholt-PARSE-prompt-engineering-final.pdf](/docs/Westholt-PARSE-prompt-engineering-final.pdf)
+Die vollständige Seminararbeit gibt es hier als PDF:
+[Westholt-PARSE-prompt-engineering-final.pdf](/docs/Westholt-PARSE-prompt-engineering-final.pdf)

--- a/src/content/blog/kickerInterview.md
+++ b/src/content/blog/kickerInterview.md
@@ -8,8 +8,9 @@ category: 'Achievements'
 tags: ['FM24', 'Interview']
 ---
 
-Als Teil des administrativen Teams von _FM Match Lab_ ehemals _FM Tweak_, wurde ich von der Zeitschrift Kicker interviewt.
+Als Teil des administrativen Teams von _FM Match Lab_ ehemals _FM Tweak_, wurde ich von der Zeitschrift Kicker
+interviewt.
 [Hier geht es zum Artikel](https://www.kicker.de/immersiver-spannender-besser-so-will-fm-tweak-den-fm24-veraendern-1109356/artikel)
 
-Wir sprachen unter anderem über die Zukunft und Grenzen von Match Engines, wie das Modding Projekt begonnen wurde und welche Ziele wir mit _FM Match Lab_ haben.
-Vielen Dank Sven für diese einzigartige Möglichkeit!
+Wir sprachen unter anderem über die Zukunft und Grenzen von Match Engines, wie das Modding Projekt begonnen wurde und
+welche Ziele wir mit _FM Match Lab_ haben. Vielen Dank Sven für diese einzigartige Möglichkeit!

--- a/src/content/blog/logoguidefm24.md
+++ b/src/content/blog/logoguidefm24.md
@@ -8,7 +8,9 @@ category: 'Football Manager'
 tags: ['FM24', 'Guide']
 ---
 
-Dieser Guide wird dir helfen, Logos für den Football Manager 24 zu installieren. Nicht jedes Logo ist im FM24 lizenziert und dieser Guide wird dir dabei helfen, mehr Immersion in dein Spiel zu bringen. Ich werde auch erklären, wie man die config.xml ändert und Lösungen für Probleme aufzeigen, auf die ich gestoßen bin.
+Dieser Guide wird dir helfen, Logos für den Football Manager 24 zu installieren. Nicht jedes Logo ist im FM24 lizenziert
+und dieser Guide wird dir dabei helfen, mehr Immersion in dein Spiel zu bringen. Ich werde auch erklären, wie man die
+config.xml ändert und Lösungen für Probleme aufzeigen, auf die ich gestoßen bin.
 
 ## Wie man installiert
 
@@ -17,30 +19,38 @@ Dieser Guide wird dir helfen, Logos für den Football Manager 24 zu installieren
 
 _C:\Dokumente\Sports Interactive\Football Manager 2024\graphics_
 
-Es sollte ungefähr so aussehen: ![Screenshot](../../assets/images/FootballManager/fpguide2.jpg)
-Wenn du keinen graphics-Ordner hast, musst du ihn erstellen.
+Es sollte ungefähr so aussehen: ![Screenshot](../../assets/images/FootballManager/fpguide2.jpg) Wenn du keinen
+graphics-Ordner hast, musst du ihn erstellen.
 
-3. Entpacke die Zip-Datei. Möglicherweise benötigst du dafür 7-Zip (ein kostenloses Programm). Öffne einfach die Zip-Datei und verschiebe den gesamten Inhalt in den graphics-Ordner.
-4. Nun müssen wir unsere Dateien laden:
-   Gehe im Spiel auf Einstellungen -> Interface -> stelle sicher, dass der Cache deaktiviert ist -> Skin neu laden ![Screenshot](../../assets/images/FootballManager/stadiumguide11.png)
+3. Entpacke die Zip-Datei. Möglicherweise benötigst du dafür 7-Zip (ein kostenloses Programm). Öffne einfach die
+   Zip-Datei und verschiebe den gesamten Inhalt in den graphics-Ordner.
+4. Nun müssen wir unsere Dateien laden: Gehe im Spiel auf Einstellungen -> Interface -> stelle sicher, dass der Cache
+   deaktiviert ist -> Skin neu laden ![Screenshot](../../assets/images/FootballManager/stadiumguide11.png)
 
 Lade einen Spielstand und schau, ob es funktioniert. Wenn ja, viel Spaß!
 
 ## Wie man Probleme behebt
 
-Wenn es nicht funktioniert, müssen wir vielleicht etwas Feintuning betreiben. Das liegt entweder daran, dass du andere Logos installiert hast, oder dass andere Teams geladen sind, die diese "einzigartige" ID beanspruchen. Wenn du bereits andere Logos installiert hast, solltest du vielleicht mit [Schritt 12](#schritt-12) beginnen.
+Wenn es nicht funktioniert, müssen wir vielleicht etwas Feintuning betreiben. Das liegt entweder daran, dass du andere
+Logos installiert hast, oder dass andere Teams geladen sind, die diese "einzigartige" ID beanspruchen. Wenn du bereits
+andere Logos installiert hast, solltest du vielleicht mit [Schritt 12](#schritt-12) beginnen.
 
 <a id="schritt-5"></a>
 
-5. Lade dein Spiel und überprüfe die IDs der Teams. Ich werde Blue Lock aus meinem eigenen Datensatz als Beispiel verwenden. Aktiviere dafür "Zeige Screen-IDs in der Titelleiste" in den Einstellungen. ![Screenshot](../../assets/images/FootballManager/stadiumguide7.png)
-6. Lade einen Spielstand und klicke auf das Blue Lock Team. Du solltest nun die ID in der oberen Ecke sehen. ![Screenshot](../../assets/images/FootballManager/logoguide1.jpg)
-7. Öffne deinen graphics-Ordner und vergleiche die IDs meiner Dateien mit dieser ID.
-   Wie du sehen kannst, ist sie in meinem Fall korrekt. Die ID im Spiel ist dieselbe wie auf dem PNG. ![Screenshot](../../assets/images/FootballManager/logoguide2.jpg)
+5. Lade dein Spiel und überprüfe die IDs der Teams. Ich werde Blue Lock aus meinem eigenen Datensatz als Beispiel
+   verwenden. Aktiviere dafür "Zeige Screen-IDs in der Titelleiste" in den Einstellungen.
+   ![Screenshot](../../assets/images/FootballManager/stadiumguide7.png)
+6. Lade einen Spielstand und klicke auf das Blue Lock Team. Du solltest nun die ID in der oberen Ecke sehen.
+   ![Screenshot](../../assets/images/FootballManager/logoguide1.jpg)
+7. Öffne deinen graphics-Ordner und vergleiche die IDs meiner Dateien mit dieser ID. Wie du sehen kannst, ist sie in
+   meinem Fall korrekt. Die ID im Spiel ist dieselbe wie auf dem PNG.
+   ![Screenshot](../../assets/images/FootballManager/logoguide2.jpg)
 8. Wenn sie nicht übereinstimmen, musst du das PNG-Bild in die ID umbenennen, die im Spiel angezeigt wird.
 
 <a id="schritt-9"></a>
 
-9. Du musst auch die config.xml öffnen und die ID ändern. Es ist wichtig, die ID zweimal umzubenennen. Ich habe beide Zahlen markiert, die du in der config ändern musst.
+9. Du musst auch die config.xml öffnen und die ID ändern. Es ist wichtig, die ID zweimal umzubenennen. Ich habe beide
+   Zahlen markiert, die du in der config ändern musst.
 
 Beispiel-Config für Normal:
 
@@ -69,15 +79,23 @@ Beispiel-Config für Small:
 ![Screenshot](../../assets/images/FootballManager/logoguide3.jpg)
 
 10. Du musst das für beide Ordner tun. Für "normal" und "small". **Achte darauf, die richtige Bildgröße zu verwenden.**
-11. Nun müssen wir unsere Dateien neu laden:
-    Gehe im Spiel auf Einstellungen -> Interface -> stelle sicher, dass der Cache deaktiviert ist -> Skin neu laden ![Screenshot](../../assets/images/FootballManager/stadiumguide11.png)
+11. Nun müssen wir unsere Dateien neu laden: Gehe im Spiel auf Einstellungen -> Interface -> stelle sicher, dass der
+    Cache deaktiviert ist -> Skin neu laden ![Screenshot](../../assets/images/FootballManager/stadiumguide11.png)
 
 <a id="schritt-12"></a>
 
-12. Wenn es immer noch nicht funktioniert, könnte es an anderen Logos liegen, die du installiert hast.
-    Öffne den Ordner, in dem sich die anderen Logos befinden. Wenn er eine andere Dateistruktur hat als meiner, suche nach dem "clubs"-Ordner. ![Screenshot](../../assets/images/FootballManager/logoguide4.jpg)
-13. In diesem Ordner solltest du die Unterordner "small" und "normal" finden. Öffne nacheinander beide Ordner und platziere dort nur die PNGs für die Logos und Icons, die du ersetzen möchtest. Nicht die config.xml! Wiederhole nun [Schritt 5](#schritt-5) bis Schritt 8. Möglicherweise musst du bestimmte PNGs ersetzen, wenn sie dieselbe ID verwenden. Stelle sicher, dass du die ID im Spiel überprüfst ([Schritt 5](#schritt-5)), bevor du etwas ersetzt. Außerdem solltest du Kopien von Dateien anlegen, die du nicht verlieren möchtest.
-14. Du solltest nun einen Ordner voller PNGs mit den richtigen IDs und einer alten config haben. Kopiere die config.xml zur Sicherheit auf deinen Desktop, falls du etwas kaputt machst. Nun musst du nur noch die alte config.xml bearbeiten. Öffne sie und ändere die ID, (wie in [Schritt 9](#schritt-9) beschrieben) zu der ID im Spiel und füge sie in die Liste ein.
+12. Wenn es immer noch nicht funktioniert, könnte es an anderen Logos liegen, die du installiert hast. Öffne den Ordner,
+    in dem sich die anderen Logos befinden. Wenn er eine andere Dateistruktur hat als meiner, suche nach dem
+    "clubs"-Ordner. ![Screenshot](../../assets/images/FootballManager/logoguide4.jpg)
+13. In diesem Ordner solltest du die Unterordner "small" und "normal" finden. Öffne nacheinander beide Ordner und
+    platziere dort nur die PNGs für die Logos und Icons, die du ersetzen möchtest. Nicht die config.xml! Wiederhole nun
+    [Schritt 5](#schritt-5) bis Schritt 8. Möglicherweise musst du bestimmte PNGs ersetzen, wenn sie dieselbe ID
+    verwenden. Stelle sicher, dass du die ID im Spiel überprüfst ([Schritt 5](#schritt-5)), bevor du etwas ersetzt.
+    Außerdem solltest du Kopien von Dateien anlegen, die du nicht verlieren möchtest.
+14. Du solltest nun einen Ordner voller PNGs mit den richtigen IDs und einer alten config haben. Kopiere die config.xml
+    zur Sicherheit auf deinen Desktop, falls du etwas kaputt machst. Nun musst du nur noch die alte config.xml
+    bearbeiten. Öffne sie und ändere die ID, (wie in [Schritt 9](#schritt-9) beschrieben) zu der ID im Spiel und füge
+    sie in die Liste ein.
 
 Im "normal"-Ordner:
 
@@ -92,7 +110,8 @@ Im "small"-Ordner:
 ```
 
 Kopiere diese Zeile und ändere die Zahlen zur Unique ID deiner Dateien. Platziere sie in der Liste (`<list id="maps">`).
-Deine config.xml wird dadurch sehr viel größer sein. Du kannst den Eintrag jedoch überall in diese Liste setzen. Ich empfehle, ihn ganz oben oder unten in der Liste zu platzieren, falls du ihn noch einmal ändern oder löschen musst.
+Deine config.xml wird dadurch sehr viel größer sein. Du kannst den Eintrag jedoch überall in diese Liste setzen. Ich
+empfehle, ihn ganz oben oder unten in der Liste zu platzieren, falls du ihn noch einmal ändern oder löschen musst.
 
 Beispiel-Config für Normal:
 
@@ -106,10 +125,13 @@ Beispiel-Config für Normal:
 </record>
 ```
 
-15. Diesen Prozess musst du sowohl für den "small"- als auch für den "normal"-Ordner durchführen. Es reicht jedoch in der Regel aus, die neuen Zeilen in deine config.xml zu kopieren und das Wort "logo" in "icon" umzuwandeln (oder umgekehrt). Dann musst du nur noch die PNGs platzieren und umbenennen.
-16. Jetzt laden wir unsere Dateien ein letztes Mal neu:
-    Gehe im Spiel auf Einstellungen -> Interface -> stelle sicher, dass der Cache deaktiviert ist -> Skin neu laden !Screenshot
+15. Diesen Prozess musst du sowohl für den "small"- als auch für den "normal"-Ordner durchführen. Es reicht jedoch in
+    der Regel aus, die neuen Zeilen in deine config.xml zu kopieren und das Wort "logo" in "icon" umzuwandeln (oder
+    umgekehrt). Dann musst du nur noch die PNGs platzieren und umbenennen.
+16. Jetzt laden wir unsere Dateien ein letztes Mal neu: Gehe im Spiel auf Einstellungen -> Interface -> stelle sicher,
+    dass der Cache deaktiviert ist -> Skin neu laden !Screenshot
 
 ## Abschließende Gedanken
 
-Das sollte alles abdecken. Das Verwalten der config.xml kann etwas mühsam sein. Achte einfach darauf, immer die richtigen IDs und Dateigrößen zu verwenden.
+Das sollte alles abdecken. Das Verwalten der config.xml kann etwas mühsam sein. Achte einfach darauf, immer die
+richtigen IDs und Dateigrößen zu verwenden.

--- a/src/content/blog/projectbluelock24.md
+++ b/src/content/blog/projectbluelock24.md
@@ -10,27 +10,38 @@ tags: ['FM24', 'Blue Lock', 'Projects']
 
 ## Was ist Projekt Blue Lock?
 
-_Blue Lock_ ist eine von mir erstellte Datenbankmodifikation für _Football Manager 24_. Dabei habe ich die Charaktere aus dem beliebten Manga Blue Lock in die Welt des _FM24_ übertragen. Jeder Spieler, der im Manga eine Rolle spielt, wurde mit individuellen Attributen, Persönlichkeitsprofilen und potenziellen Karrieren ins Spiel integriert.
+_Blue Lock_ ist eine von mir erstellte Datenbankmodifikation für _Football Manager 24_. Dabei habe ich die Charaktere
+aus dem beliebten Manga Blue Lock in die Welt des _FM24_ übertragen. Jeder Spieler, der im Manga eine Rolle spielt,
+wurde mit individuellen Attributen, Persönlichkeitsprofilen und potenziellen Karrieren ins Spiel integriert.
 
 ### War es ein Erfolg?
 
-Meine Spieldateien wurden inzwischen über 5000 Mal heruntergeladen. Rund um die Mod hat sich bereits eine kleine Community gebildet, die meine Arbeit aufgreift, weiterentwickelt und an eigene Vorstellungen anpasst. Wenn du auch ein Teil dieser Community sein möchtest, tritt doch meinem [Discord](https://discord.gg/G8hRPd47JS) bei.
-Natürlich ist es eine Herausforderung, fiktive Manga-Charaktere glaubwürdig in eine realistische Fußballsimulation wie _Football Manager_ zu übertragen. Dennoch bin ich mit dem bisherigen Ergebnis sehr zufrieden – unter den gegebenen Umständen würde ich sagen: Ja, es war ein Erfolg.
+Meine Spieldateien wurden inzwischen über 5000 Mal heruntergeladen. Rund um die Mod hat sich bereits eine kleine
+Community gebildet, die meine Arbeit aufgreift, weiterentwickelt und an eigene Vorstellungen anpasst. Wenn du auch ein
+Teil dieser Community sein möchtest, tritt doch meinem [Discord](https://discord.gg/G8hRPd47JS) bei. Natürlich ist es
+eine Herausforderung, fiktive Manga-Charaktere glaubwürdig in eine realistische Fußballsimulation wie _Football Manager_
+zu übertragen. Dennoch bin ich mit dem bisherigen Ergebnis sehr zufrieden – unter den gegebenen Umständen würde ich
+sagen: Ja, es war ein Erfolg.
 
 ### Wo kann man die Datei herunterladen?
 
-Ich habe bereits mehrere Versionen der Projekt Blue Lock-Mod veröffentlicht – von frühen Testfassungen bis hin zu ausgereiften Updates mit neuen Spielern und Anpassungen.
-Ich veröffentliche alle meine Versionen auf [Patreon](https://www.patreon.com/c/legolukas).
-Sobald ich mit dem Testen meiner Datein fertig bin, werden diese auf
-[FM Scout](https://www.fmscout.com/users/Legolukas.html) und im [Steam Workshop](https://steamcommunity.com/id/polizei_zugriff/myworkshopfiles/) veröffentlicht.
+Ich habe bereits mehrere Versionen der Projekt Blue Lock-Mod veröffentlicht – von frühen Testfassungen bis hin zu
+ausgereiften Updates mit neuen Spielern und Anpassungen. Ich veröffentliche alle meine Versionen auf
+[Patreon](https://www.patreon.com/c/legolukas). Sobald ich mit dem Testen meiner Datein fertig bin, werden diese auf
+[FM Scout](https://www.fmscout.com/users/Legolukas.html) und im
+[Steam Workshop](https://steamcommunity.com/id/polizei_zugriff/myworkshopfiles/) veröffentlicht.
 
 ### Wie hast du die Modifikationen erstellt?
 
-Zur Erstellung der Mod habe ich den offiziellen _Pre-Game Editor_ für _Football Manager 2024_ verwendet. Mit diesem Tool lassen sich Spieler, Vereine, Wettbewerbe und viele andere Elemente der Datenbank gezielt bearbeiten oder neu erstellen.
-Ich habe für jeden Blue Lock-Charakter eigene Spielerprofile angelegt – inklusive realistischer Attribute, Persönlichkeitswerte, Herkunft und Potenzial.
-Der gesamte Prozess war zeitintensiv, besonders die Balance zwischen Manga-Fiktion und FM-Realismus zu finden. Aber genau das macht den Reiz dieses Projekts aus.
+Zur Erstellung der Mod habe ich den offiziellen _Pre-Game Editor_ für _Football Manager 2024_ verwendet. Mit diesem Tool
+lassen sich Spieler, Vereine, Wettbewerbe und viele andere Elemente der Datenbank gezielt bearbeiten oder neu erstellen.
+Ich habe für jeden Blue Lock-Charakter eigene Spielerprofile angelegt – inklusive realistischer Attribute,
+Persönlichkeitswerte, Herkunft und Potenzial. Der gesamte Prozess war zeitintensiv, besonders die Balance zwischen
+Manga-Fiktion und FM-Realismus zu finden. Aber genau das macht den Reiz dieses Projekts aus.
 
 ## Fazit
 
-_Projekt Blue Lock_ ist mein Versuch, die kreative Welt eines Mangas mit der Tiefe einer Fußballsimulation zu verbinden. Trotz der Herausforderungen, fiktive Figuren in ein realistisches Spiel zu integrieren, hat die Modifikation eine tolle Resonanz bekommen.
-Ich freue mich, dass das Projekt so viele Spieler\*innen begeistert hat, und bin gespannt, wie sich Blue Lock im FM-Universum weiterentwickelt – sei es durch meine Updates oder durch eure eigenen Anpassungen.
+_Projekt Blue Lock_ ist mein Versuch, die kreative Welt eines Mangas mit der Tiefe einer Fußballsimulation zu verbinden.
+Trotz der Herausforderungen, fiktive Figuren in ein realistisches Spiel zu integrieren, hat die Modifikation eine tolle
+Resonanz bekommen. Ich freue mich, dass das Projekt so viele Spieler\*innen begeistert hat, und bin gespannt, wie sich
+Blue Lock im FM-Universum weiterentwickelt – sei es durch meine Updates oder durch eure eigenen Anpassungen.

--- a/src/content/blog/projectbluelock26.md
+++ b/src/content/blog/projectbluelock26.md
@@ -10,27 +10,39 @@ tags: ['FM26', 'Blue Lock', 'Projects']
 
 ## Was ist Projekt Blue Lock?
 
-_Blue Lock_ ist eine von mir erstellte Datenbankmodifikation für _Football Manager 26_ und die Fortsetzung meiner Datenbank von _Football Manager 24_ Dabei habe ich die Charaktere aus dem beliebten Manga Blue Lock in die Welt des _FM26_ übertragen. Jeder Spieler, der im Manga eine Rolle spielt, wurde mit individuellen Attributen, Persönlichkeitsprofilen und potenziellen Karrieren ins Spiel integriert.
+_Blue Lock_ ist eine von mir erstellte Datenbankmodifikation für _Football Manager 26_ und die Fortsetzung meiner
+Datenbank von _Football Manager 24_ Dabei habe ich die Charaktere aus dem beliebten Manga Blue Lock in die Welt des
+_FM26_ übertragen. Jeder Spieler, der im Manga eine Rolle spielt, wurde mit individuellen Attributen,
+Persönlichkeitsprofilen und potenziellen Karrieren ins Spiel integriert.
 
 ### War es ein Erfolg?
 
-Meine Spieldateien wurden inzwischen über 1500 Mal heruntergeladen. Rund um die Mod hat sich bereits eine kleine Community gebildet, die meine Arbeit aufgreift, weiterentwickelt und an eigene Vorstellungen anpasst. Wenn du auch ein Teil dieser Community sein möchtest, tritt doch meinem [Discord](https://discord.gg/G8hRPd47JS) bei.
-Natürlich ist es eine Herausforderung, fiktive Manga-Charaktere glaubwürdig in eine realistische Fußballsimulation wie _Football Manager_ zu übertragen. Dennoch bin ich mit dem bisherigen Ergebnis sehr zufrieden – unter den gegebenen Umständen würde ich sagen: Ja, es war ein Erfolg.
+Meine Spieldateien wurden inzwischen über 1500 Mal heruntergeladen. Rund um die Mod hat sich bereits eine kleine
+Community gebildet, die meine Arbeit aufgreift, weiterentwickelt und an eigene Vorstellungen anpasst. Wenn du auch ein
+Teil dieser Community sein möchtest, tritt doch meinem [Discord](https://discord.gg/G8hRPd47JS) bei. Natürlich ist es
+eine Herausforderung, fiktive Manga-Charaktere glaubwürdig in eine realistische Fußballsimulation wie _Football Manager_
+zu übertragen. Dennoch bin ich mit dem bisherigen Ergebnis sehr zufrieden – unter den gegebenen Umständen würde ich
+sagen: Ja, es war ein Erfolg.
 
 ### Wo kann man die Datei herunterladen?
 
-Ich habe bereits mehrere Versionen der Projekt Blue Lock-Mod veröffentlicht – von frühen Testfassungen bis hin zu ausgereiften Updates mit neuen Spielern und Anpassungen.
-Ich veröffentliche alle meine Versionen auf [Patreon](https://www.patreon.com/c/legolukas).
-Sobald ich mit dem Testen meiner Datein fertig bin, werden diese auf
-[FM Scout](https://www.fmscout.com/users/Legolukas.html) und im [Steam Workshop](https://steamcommunity.com/id/polizei_zugriff/myworkshopfiles/) veröffentlicht.
+Ich habe bereits mehrere Versionen der Projekt Blue Lock-Mod veröffentlicht – von frühen Testfassungen bis hin zu
+ausgereiften Updates mit neuen Spielern und Anpassungen. Ich veröffentliche alle meine Versionen auf
+[Patreon](https://www.patreon.com/c/legolukas). Sobald ich mit dem Testen meiner Datein fertig bin, werden diese auf
+[FM Scout](https://www.fmscout.com/users/Legolukas.html) und im
+[Steam Workshop](https://steamcommunity.com/id/polizei_zugriff/myworkshopfiles/) veröffentlicht.
 
 ### Wie hast du die Modifikationen erstellt?
 
-Zur Erstellung der Mod habe ich den offiziellen _Pre-Game Editor_ für _Football Manager 2026_ verwendet. Mit diesem Tool lassen sich Spieler, Vereine, Wettbewerbe und viele andere Elemente der Datenbank gezielt bearbeiten oder neu erstellen.
-Ich habe für jeden Blue Lock-Charakter eigene Spielerprofile angelegt – inklusive realistischer Attribute, Persönlichkeitswerte, Herkunft und Potenzial.
-Der gesamte Prozess war zeitintensiv, besonders die Balance zwischen Manga-Fiktion und FM-Realismus zu finden. Aber genau das macht den Reiz dieses Projekts aus.
+Zur Erstellung der Mod habe ich den offiziellen _Pre-Game Editor_ für _Football Manager 2026_ verwendet. Mit diesem Tool
+lassen sich Spieler, Vereine, Wettbewerbe und viele andere Elemente der Datenbank gezielt bearbeiten oder neu erstellen.
+Ich habe für jeden Blue Lock-Charakter eigene Spielerprofile angelegt – inklusive realistischer Attribute,
+Persönlichkeitswerte, Herkunft und Potenzial. Der gesamte Prozess war zeitintensiv, besonders die Balance zwischen
+Manga-Fiktion und FM-Realismus zu finden. Aber genau das macht den Reiz dieses Projekts aus.
 
 ## Fazit
 
-_Projekt Blue Lock_ ist mein Versuch, die kreative Welt eines Mangas mit der Tiefe einer Fußballsimulation zu verbinden. Trotz der Herausforderungen, fiktive Figuren in ein realistisches Spiel zu integrieren, hat die Modifikation eine tolle Resonanz bekommen.
-Ich freue mich, dass das Projekt so viele Spieler\*innen begeistert hat, und bin gespannt, wie sich Blue Lock im FM-Universum weiterentwickelt – sei es durch meine Updates oder durch eure eigenen Anpassungen.
+_Projekt Blue Lock_ ist mein Versuch, die kreative Welt eines Mangas mit der Tiefe einer Fußballsimulation zu verbinden.
+Trotz der Herausforderungen, fiktive Figuren in ein realistisches Spiel zu integrieren, hat die Modifikation eine tolle
+Resonanz bekommen. Ich freue mich, dass das Projekt so viele Spieler\*innen begeistert hat, und bin gespannt, wie sich
+Blue Lock im FM-Universum weiterentwickelt – sei es durch meine Updates oder durch eure eigenen Anpassungen.

--- a/src/content/blog/scraperino.md
+++ b/src/content/blog/scraperino.md
@@ -10,21 +10,27 @@ tags: ['Projects', 'Scraperino']
 
 ## Was ist Scraperino?
 
-_Scraperino_ ist eine umfassende Full-Stack-Webanwendung, die entwickelt wurde, um Produktdaten und Angebote von Online-Marktplätzen – speziell _eBay_ (weltweit) und _Kleinanzeigen_ – automatisiert auszulesen (Scraping).
-Die Architektur besteht aus einem Python-Backend (betrieben mit FastAPI und Playwright) und einem React-Frontend (betrieben mit Vite und Node.js).
+_Scraperino_ ist eine umfassende Full-Stack-Webanwendung, die entwickelt wurde, um Produktdaten und Angebote von
+Online-Marktplätzen – speziell _eBay_ (weltweit) und _Kleinanzeigen_ – automatisiert auszulesen (Scraping). Die
+Architektur besteht aus einem Python-Backend (betrieben mit FastAPI und Playwright) und einem React-Frontend (betrieben
+mit Vite und Node.js).
 
 ### Features
 
-Nutzer können nach mehreren Suchbegriffen gleichzeitig suchen, genaue Parameter (wie Preisgrenzen oder Zustände) vorgeben und das System extrahiert dann alle passenden Angebote. Am Ende werden die gesammelten, aufbereiteten Daten in einer übersichtlichen Excel-Datei bereitgestellt.
+Nutzer können nach mehreren Suchbegriffen gleichzeitig suchen, genaue Parameter (wie Preisgrenzen oder Zustände)
+vorgeben und das System extrahiert dann alle passenden Angebote. Am Ende werden die gesammelten, aufbereiteten Daten in
+einer übersichtlichen Excel-Datei bereitgestellt.
 
 - Multi-Plattform & Regionen-Unterstützung
 - - Unterstützt Kleinanzeigen (.de)
-- - Unterstützt eBay in zahlreichen internationalen Regionen (DE, US, UK, AT, CH, FR, IT, ES, etc.) inkl. Währungsumrechnungslogik
+- - Unterstützt eBay in zahlreichen internationalen Regionen (DE, US, UK, AT, CH, FR, IT, ES, etc.) inkl.
+    Währungsumrechnungslogik
 - Detaillierte Filter & Suchkriterien
 - - Preisfilter: Minimal- und Maximalpreis können festgelegt werden
 - - Zustandsfilter: Beschränkung auf Neu, Gebraucht, Generalüberholt oder Defekt/Ersatzteil
 - - Angebotsformate (eBay): Filterung nach Auktionen, Sofort-Kaufen oder Preisvorschlägen
-- - Angebotsstatus (eBay): Suche nach aktuell aktiven Angeboten, aber auch nach verkauften oder beendeten Artikeln (nützlich für Preisrecherchen)
+- - Angebotsstatus (eBay): Suche nach aktuell aktiven Angeboten, aber auch nach verkauften oder beendeten Artikeln
+    (nützlich für Preisrecherchen)
 - - Verbotene Wörter (Blacklist): Begriffe, die im Titel vorkommen, führen zum sofortigen Aussortieren des Artikels
 - Duplikate werden herausgefiltert
 - Intelligentes Anti-Bot-Management & Captcha-Handling
@@ -34,19 +40,25 @@ Nutzer können nach mehreren Suchbegriffen gleichzeitig suchen, genaue Parameter
 
 ### Ablauf
 
-Das System nutzt Playwright mit "Stealth"-Einstellungen, um nicht direkt als Bot erkannt zu werden.
-Live-View & Eingriff: Erkennt das System Captchas (z. B. DataDome bei Kleinanzeigen) oder Blockaden (Akamai oder Login-Pflicht bei eBay), bricht es nicht sofort ab. Wenn der Nutzer den "Live-View" aktiviert hat, pausiert der Scraper für 5 Minuten und warnt den Nutzer über das Frontend, das Problem im Browser manuell zu lösen (z.B. ein Captcha wegzuklicken). Danach arbeitet das Skript nahtlos weiter.
-Dank WebSockets erhält das React-Frontend in Echtzeit Updates aus dem Python-Backend.
-Der Nutzer sieht einen Live-Tracker, der genau zeigt, welche Seite gerade durchsucht wird, wie viele Treffer ("Hits") gefunden, wie viele aussortiert ("gefiltert") und wie viele Duplikate ignoriert wurden.
-Suchanfragen (Queries) und Plattformen werden gebündelt und mithilfe von asynchronen Tasks (Asyncio) und parallel geöffneten Browser-Tabs bearbeitet. Die maximale Anzahl gleichzeitiger Tabs (max_tabs) kann begrenzt werden, um Systemauslastungen und IP-Sperren zu managen.
+Das System nutzt Playwright mit "Stealth"-Einstellungen, um nicht direkt als Bot erkannt zu werden. Live-View &
+Eingriff: Erkennt das System Captchas (z. B. DataDome bei Kleinanzeigen) oder Blockaden (Akamai oder Login-Pflicht bei
+eBay), bricht es nicht sofort ab. Wenn der Nutzer den "Live-View" aktiviert hat, pausiert der Scraper für 5 Minuten und
+warnt den Nutzer über das Frontend, das Problem im Browser manuell zu lösen (z.B. ein Captcha wegzuklicken). Danach
+arbeitet das Skript nahtlos weiter. Dank WebSockets erhält das React-Frontend in Echtzeit Updates aus dem
+Python-Backend. Der Nutzer sieht einen Live-Tracker, der genau zeigt, welche Seite gerade durchsucht wird, wie viele
+Treffer ("Hits") gefunden, wie viele aussortiert ("gefiltert") und wie viele Duplikate ignoriert wurden. Suchanfragen
+(Queries) und Plattformen werden gebündelt und mithilfe von asynchronen Tasks (Asyncio) und parallel geöffneten
+Browser-Tabs bearbeitet. Die maximale Anzahl gleichzeitiger Tabs (max_tabs) kann begrenzt werden, um Systemauslastungen
+und IP-Sperren zu managen.
 
-Alle Suchergebnisse werden bereinigt und in eine .xlsx-Datei (Excel) geschrieben (excel_writer.py).
-Die Datei enthält klickbare Links, vorformatierte Währungen/Preise, Gesamtkosten (Preis + Versand) und sauber getrennte Spalten (Titel, Plattform, Zustand, Typ, Verhandelbar).
-Automatische Deduplizierung stellt sicher, dass exakt gleiche Links nicht mehrfach in der Excel-Tabelle landen.
-Zweisprachigkeit (Lokalisierung)
+Alle Suchergebnisse werden bereinigt und in eine .xlsx-Datei (Excel) geschrieben (excel_writer.py). Die Datei enthält
+klickbare Links, vorformatierte Währungen/Preise, Gesamtkosten (Preis + Versand) und sauber getrennte Spalten (Titel,
+Plattform, Zustand, Typ, Verhandelbar). Automatische Deduplizierung stellt sicher, dass exakt gleiche Links nicht
+mehrfach in der Excel-Tabelle landen. Zweisprachigkeit (Lokalisierung)
 
 Die Anwendung (Logs, UI, Excel-Spalten) ist vollständig in Deutsch und Englisch verfügbar (localization.py).
 
 ### Zusammenfassung
 
-Zusammenfassend ist Scraperino ein sehr fortgeschrittener, asynchroner Web-Scraper mit Fokus auf Robustheit (Captcha-Handling) und Benutzerfreundlichkeit (visuelles Interface, Echtzeit-Feedback, formatierte Exporte).
+Zusammenfassend ist Scraperino ein sehr fortgeschrittener, asynchroner Web-Scraper mit Fokus auf Robustheit
+(Captcha-Handling) und Benutzerfreundlichkeit (visuelles Interface, Echtzeit-Feedback, formatierte Exporte).

--- a/src/content/blog/stadiumguidefm24.md
+++ b/src/content/blog/stadiumguidefm24.md
@@ -8,8 +8,10 @@ category: 'Football Manager'
 tags: ['FM24', 'Guide']
 ---
 
-Hast du dich jemals gefragt, wie du im FM24 ein eigenes Stadionbild für dein Team oder sogar ein komplett selbsterstelltes Team bekommen kannst? Dann musst du nicht weiter suchen. Ich bin hier, um dir zu zeigen, wie das geht! Ich werde das Team "Rejects" aus meinem Blue Lock Datensatz als Beispiel verwenden, aber das funktioniert für jedes Team.
-Hier ist ein Beispiel, wie es aussehen könnte:
+Hast du dich jemals gefragt, wie du im FM24 ein eigenes Stadionbild für dein Team oder sogar ein komplett
+selbsterstelltes Team bekommen kannst? Dann musst du nicht weiter suchen. Ich bin hier, um dir zu zeigen, wie das geht!
+Ich werde das Team "Rejects" aus meinem Blue Lock Datensatz als Beispiel verwenden, aber das funktioniert für jedes
+Team. Hier ist ein Beispiel, wie es aussehen könnte:
 ![Screenshot](../../assets/images/FootballManager/stadiumguide1.png)
 
 ## Schritt 1. - Vorbereitung
@@ -24,40 +26,47 @@ Nun, das ist im Grunde alles.
 
 ## Schritt 2. – Ein Stadion erstellen
 
-Dieser Schritt ist nur wichtig, wenn du ein neues Stadion erstellen willst. Wenn du einfach das Bild eines existierenden Stadions ersetzen möchtest, kannst du dies überspringen.
+Dieser Schritt ist nur wichtig, wenn du ein neues Stadion erstellen willst. Wenn du einfach das Bild eines existierenden
+Stadions ersetzen möchtest, kannst du dies überspringen.
 
-Starte den Pre Game Editor. Lade den Datensatz, den du bearbeiten möchtest, und gehe zu „Stadien“. Du kannst entweder ein Stadion von hier kopieren oder ein neues erstellen. ![Screenshot](../../assets/images/FootballManager/stadiumguide2.png)
-Hier kannst du alles an deinem Stadion ändern, was du möchtest. Fühle dich frei, zu experimentieren. Der wichtige Teil in diesem Fenster ist die eindeutige ID (Unique ID). Diese musst du dir notieren. ![Screenshot](../../assets/images/FootballManager/stadiumguide3.png)
+Starte den Pre Game Editor. Lade den Datensatz, den du bearbeiten möchtest, und gehe zu „Stadien“. Du kannst entweder
+ein Stadion von hier kopieren oder ein neues erstellen.
+![Screenshot](../../assets/images/FootballManager/stadiumguide2.png) Hier kannst du alles an deinem Stadion ändern, was
+du möchtest. Fühle dich frei, zu experimentieren. Der wichtige Teil in diesem Fenster ist die eindeutige ID (Unique ID).
+Diese musst du dir notieren. ![Screenshot](../../assets/images/FootballManager/stadiumguide3.png)
 
 In meinem Fall ist das die 2000342656.
 
-Wir müssen nun auch dieses Stadion für den gewünschten Verein auswählen.
-Gehe also zu „Vereine“ und suche nach deinem Team. In meinem Fall ist es „Rejects“. ![Screenshot ]](../../assets/images/FootballManager/stadiumguide4.png)
-Klicke auf Bearbeiten und gehe zu Stadion. ![Screenshot](../../assets/images/FootballManager/stadiumguide5.png) Dort musst du das Stadion auf das ändern, welches du gerade erstellt hast. In meinem Fall ist es die Rejects Arena.
-Speichere den Datensatz.
-![Screenshot](../../assets/images/FootballManager/stadiumguide6.png)
+Wir müssen nun auch dieses Stadion für den gewünschten Verein auswählen. Gehe also zu „Vereine“ und suche nach deinem
+Team. In meinem Fall ist es „Rejects“. ![Screenshot ]](../../assets/images/FootballManager/stadiumguide4.png) Klicke auf
+Bearbeiten und gehe zu Stadion. ![Screenshot](../../assets/images/FootballManager/stadiumguide5.png) Dort musst du das
+Stadion auf das ändern, welches du gerade erstellt hast. In meinem Fall ist es die Rejects Arena. Speichere den
+Datensatz. ![Screenshot](../../assets/images/FootballManager/stadiumguide6.png)
 
 ## Schritt 3. - Dateistruktur
 
-Lass uns nun zum etwas komplizierteren Teil kommen. Die Dateien in den richtigen Ordner packen und die config.xml erstellen.
+Lass uns nun zum etwas komplizierteren Teil kommen. Die Dateien in den richtigen Ordner packen und die config.xml
+erstellen.
 
 Was wir brauchen:
 
 - das .jpg in 800 x 480 Pixeln oder kleiner
 - die einzigartige ID (Unique ID) des Stadions.
 
-Woher bekommen wir die Unique ID?
-Entweder aus dem Pre Game Editor, wie ich es vorhin gezeigt habe, oder im Spiel, wenn du "Zeige Screen-IDs in der Titelleiste zur Fehlerbehebung" aktiviert hast. ![Screenshot](../../assets/images/FootballManager/stadiumguide7.png) ![Screenshot](../../assets/images/FootballManager/stadiumguide8.png)
+Woher bekommen wir die Unique ID? Entweder aus dem Pre Game Editor, wie ich es vorhin gezeigt habe, oder im Spiel, wenn
+du "Zeige Screen-IDs in der Titelleiste zur Fehlerbehebung" aktiviert hast.
+![Screenshot](../../assets/images/FootballManager/stadiumguide7.png)
+![Screenshot](../../assets/images/FootballManager/stadiumguide8.png)
 
-Okay, fangen wir an.
-Gehe zu deinem graphics-Ordner. Wenn du keinen hast, musst du ihn erstellen. Er befindet sich meistens unter:
-**C:\Dokumente\Sports Interactive\Football Manager 2024\graphics**
+Okay, fangen wir an. Gehe zu deinem graphics-Ordner. Wenn du keinen hast, musst du ihn erstellen. Er befindet sich
+meistens unter: **C:\Dokumente\Sports Interactive\Football Manager 2024\graphics**
 
-Erstelle einen Ordner. Du kannst ihn nennen, wie du willst. Ich würde empfehlen, ihn ganz einfach stadiums zu nennen. ![Screenshot](../../assets/images/FootballManager/stadiumguide9.png)
-Öffne den Ordner und verschiebe das .jpg dorthin. Benenne das .jpg in die Unique ID um. In meinem Fall ist das 2000342656. Dein Ordner sollte nun ungefähr so aussehen: ![Screenshot](../../assets/images/FootballManager/stadiumguide10.png)
+Erstelle einen Ordner. Du kannst ihn nennen, wie du willst. Ich würde empfehlen, ihn ganz einfach stadiums zu nennen.
+![Screenshot](../../assets/images/FootballManager/stadiumguide9.png) Öffne den Ordner und verschiebe das .jpg dorthin.
+Benenne das .jpg in die Unique ID um. In meinem Fall ist das 2000342656. Dein Ordner sollte nun ungefähr so aussehen:
+![Screenshot](../../assets/images/FootballManager/stadiumguide10.png)
 
-Erstelle nun eine Datei und nenne sie _config.xml_.
-Öffne die Datei und kopiere diesen Code hinein:
+Erstelle nun eine Datei und nenne sie _config.xml_. Öffne die Datei und kopiere diesen Code hinein:
 
 ```xml
 <record>
@@ -70,7 +79,8 @@ Erstelle nun eine Datei und nenne sie _config.xml_.
 </record>
 ```
 
-Replace **UNIQUE ID** with the correct ID. You can add multiple stadiums at the same time. Delete the 2nd record, if you only want to add a singular stadium. If you have want to add more than 2, just add more lines with the same pattern.
+Replace **UNIQUE ID** with the correct ID. You can add multiple stadiums at the same time. Delete the 2nd record, if you
+only want to add a singular stadium. If you have want to add more than 2, just add more lines with the same pattern.
 
 ![Screenshot](../../assets/images/FootballManager/stadiumguide12.png)
 
@@ -85,8 +95,9 @@ If you have a custom stadium or a custom team, make sure, to enable the Dataset 
 
 ## Problems
 
-Unfortunately, the 3D Model of the stadium might look not as good as expected, if you create a new stadium. You can't really choose what stadium you want and how it looks like.
-If your stadium has gaps, it means you can upgrade it. So for example:
-My stadium has 100000 seats. I can upgrade it to 200000. That means, that half of your stadium is not build and it will create gaps. Maybe some other setting could also influence this.
+Unfortunately, the 3D Model of the stadium might look not as good as expected, if you create a new stadium. You can't
+really choose what stadium you want and how it looks like. If your stadium has gaps, it means you can upgrade it. So for
+example: My stadium has 100000 seats. I can upgrade it to 200000. That means, that half of your stadium is not build and
+it will create gaps. Maybe some other setting could also influence this.
 
 Now everything should work. Let me know if you encounter any problem! Have a great day and enjoy playing!


### PR DESCRIPTION
## Summary
- lint-staged now runs `eslint --fix` + `prettier --write` on staged code files (`astro/js/jsx/mjs/cjs/ts/tsx`) and `prettier --write` on `md/mdx/json/yml/yaml/css`, so the existing husky pre-commit hook enforces both linting and formatting
- enable `plugin:astro/jsx-a11y-recommended` — `eslint-plugin-jsx-a11y` was installed but never referenced in the ESLint config (34 a11y rules now active on `.astro` files)
- wrap blog markdown prose in `src/content/blog/` at 120 chars via a Prettier `proseWrap: 'always'` override
- add `pnpm lint:fix` script and drop the `--plugin-search-dir` flag that Prettier 3 removed (it only produced warnings)
- second commit applies the repo-wide `pnpm format` result (25 files) so the hook produces no surprise diffs later

## Test plan
- [x] `pnpm lint` passes (including new jsx-a11y rules)
- [x] `pnpm format:check` passes
- [x] frontmatter of all re-wrapped blog posts validated as YAML with required schema fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)