### PR TITLE
Exclude draft posts from post pages and RSS feed

### DIFF
--- a/src/pages/[...lang]/post/[slug].astro
+++ b/src/pages/[...lang]/post/[slug].astro
@@ -3,7 +3,7 @@ import { getCollection } from 'astro:content'
 import BlogPost from '@/layouts/BlogPost'
 
 export async function getStaticPaths() {
-	const posts = await getCollection('blog')
+	const posts = (await getCollection('blog')).filter((post) => !post.data.draft)
 
 	return posts.map((post) => {
 		// Sprache erkennen und das "en/" aus dem Dateinamen (Slug) entfernen

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -3,7 +3,7 @@ import { getCollection } from 'astro:content'
 import { siteConfig } from '@/site-config'
 
 export async function GET(context: any) {
-	const posts = await getCollection('blog')
+	const posts = (await getCollection('blog')).filter((post) => !post.data.draft)
 	return rss({
 		title: siteConfig.title,
 		description: siteConfig.description,


### PR DESCRIPTION
## Summary
`draft: true` posts were hidden from all listing pages (which use `getPosts()` with a draft filter), but two places used `getCollection('blog')` unfiltered:

- `src/pages/[...lang]/post/[slug].astro` — draft post pages were still built, so they were reachable by URL, included in `sitemap.xml`, and indexed by the Pagefind site search
- `src/pages/rss.xml.ts` — drafts appeared in the RSS feed with title, description, and link

Both now filter out `post.data.draft` entries.

## Test plan
- [x] Full `pnpm build` with a temporary `draft: true` test post: no page in `dist/post/`, zero occurrences anywhere in `dist/` (covers RSS, sitemap, and Pagefind index)
- [x] All existing non-draft posts still built and present in RSS
- [x] `pnpm lint` and `pnpm format:check` pass on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)