### PR TITLE
fix: redirect /en/impress/ to /impress

### DIFF
--- a/src/pages/en/impress.astro
+++ b/src/pages/en/impress.astro
@@ -1,0 +1,3 @@
+---
+return Astro.redirect('/impress', 301)
+---


### PR DESCRIPTION
## Summary

- `/en/impress/` returned a 404 because no route existed for it
- Adds `src/pages/en/impress.astro` with a permanent 301 redirect to `/impress`
- The Impressum is a German legal document, so a redirect is the correct solution rather than a translation

## Test plan

- [ ] Visit `/en/impress/` and confirm redirect to `/impress`

🤖 Generated with [Claude Code](https://claude.com/claude-code)