### PR TITLE
fix: mark /impress as untranslatable in LanguageSwitcher

### DIFF
--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -32,8 +32,16 @@ if (isPostPage) {
 } else {
 	// Für alle anderen Seiten (Kategorien, Tags, Startseite) erlauben wir den Wechsel,
 	// da deine Post-Utils bei fehlenden Inhalten automatisch Fallbacks liefern!
-	if (isEnglish) {
-		targetUrl = currentPath.replace(/^\/en/, '') || '/'
+	const basePath = currentPath.replace(/^\/en/, '') || '/'
+
+	// Ausnahme: Seiten ohne Übersetzung (z.B. Impressum — deutsches Rechtsdokument)
+	const untranslatablePaths = ['/impress']
+
+	if (untranslatablePaths.includes(basePath)) {
+		hasTranslation = false
+		targetUrl = '#'
+	} else if (isEnglish) {
+		targetUrl = basePath
 	} else {
 		targetUrl = currentPath === '/' ? '/en/' : `/en${currentPath}`
 	}

--- a/src/pages/en/impress.astro
+++ b/src/pages/en/impress.astro
@@ -1,3 +1,0 @@
----
-return Astro.redirect('/impress', 301)
----


### PR DESCRIPTION
## Summary

- `/en/impress/` returned a 404; `BaseLayout` renders `LanguageSwitcher` on every page including `/impress`, so switching language built the URL `/en/impress`
- A `Astro.redirect()` page was tried first but caused a visible flash (static sites generate a `<meta http-equiv="refresh">` page, not a real HTTP redirect)
- Fix: introduce an `untranslatablePaths` list in `LanguageSwitcher.astro`; `/impress` now shows the disabled "🚫 Nicht übersetzt" state instead of navigating to a non-existent URL

## Test plan

- [x] On `/impress`, language switcher shows disabled state
- [x] On `/en/impress/` (typed directly), returns 404 — acceptable since no link leads there anymore

🤖 Generated with [Claude Code](https://claude.com/claude-code)