### PR TITLE
fix: LanguageSwitcher trailing slash + PDF link for mining study

### DIFF
--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -34,11 +34,12 @@ if (isPostPage) {
 	// Für alle anderen Seiten (Kategorien, Tags, Startseite) erlauben wir den Wechsel,
 	// da deine Post-Utils bei fehlenden Inhalten automatisch Fallbacks liefern!
 	const basePath = currentPath.replace(/^\/en/, '') || '/'
+	const normalizedPath = basePath.replace(/\/$/, '') || '/'
 
 	// Ausnahme: Seiten ohne Übersetzung (z.B. Impressum — deutsches Rechtsdokument)
 	const untranslatablePaths = ['/impress']
 
-	if (untranslatablePaths.includes(basePath)) {
+	if (untranslatablePaths.includes(normalizedPath)) {
 		hasTranslation = false
 		targetUrl = '#'
 	} else if (isEnglish) {

--- a/src/content/blog/ki-code-qualitaet-mining-studie.md
+++ b/src/content/blog/ki-code-qualitaet-mining-studie.md
@@ -57,3 +57,7 @@ Ergebnis. Die größte Schwäche bleibt die unscharfe Behandlungsgrenze: Ich mes
 ab wann ein Projekt KI-Nutzung sichtbar macht, nicht ab wann es sie wirklich
 nutzt. Der nächste Schritt wäre, von der Projektebene auf die einzelnen
 KI-zugeschriebenen Änderungen herunterzugehen.
+
+---
+
+Die vollständige Seminararbeit gibt es hier als PDF: [Westholt-PARSE-prompt-engineering-final.pdf](/docs/Westholt-PARSE-prompt-engineering-final.pdf)


### PR DESCRIPTION
## Summary

- Fix `/impress/` not matching untranslatable paths in LanguageSwitcher (trailing slash was not normalized before `includes()` check)
- Add PDF download link at the end of the mining study article

## Test plan

- [x] `/impress/` → Language Switcher shows 🚫 Nicht übersetzt
- [x] Mining study article shows PDF link at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)