### PR TITLE
feat: switch preview deployments to GitHub Deployments API

### DIFF
--- a/.github/workflows/preview_cleanup.yml
+++ b/.github/workflows/preview_cleanup.yml
@@ -30,3 +30,14 @@ jobs:
           ssh-keyscan -p ${{ vars.SERVER_PORT }} ${{ vars.SERVER_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
           lftp -e "rm -rf ${{ vars.SERVER_TARGET }}/preview/${{ steps.branch.outputs.name }}/; exit" \
             sftp://${{ vars.SERVER_USER }}:${{ secrets.SERVER_PASSWORD }}@${{ vars.SERVER_HOST }}:${{ vars.SERVER_PORT }}
+
+      - name: Deactivate GitHub deployments
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "/repos/${{ github.repository }}/deployments" \
+            --jq ".[] | select(.environment == \"preview/${{ steps.branch.outputs.name }}\") | .id" \
+          | while read -r ID; do
+            gh api "/repos/${{ github.repository }}/deployments/$ID/statuses" \
+              --method POST -f state="inactive"
+          done

--- a/.github/workflows/preview_deploy.yml
+++ b/.github/workflows/preview_deploy.yml
@@ -38,6 +38,25 @@ jobs:
           SAFE=$(echo '${{ github.head_ref }}' | tr '/' '-' | tr '_' '-' | tr '[:upper:]' '[:lower:]')
           echo "name=$SAFE" >> $GITHUB_OUTPUT
 
+      - name: Create GitHub deployment
+        id: deployment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DEPLOYMENT_ID=$(gh api "/repos/${{ github.repository }}/deployments" \
+            --method POST \
+            -f ref="${{ github.event.pull_request.head.sha }}" \
+            -f environment="preview/${{ steps.branch.outputs.name }}" \
+            -f description="Preview for PR #${{ github.event.pull_request.number }}" \
+            -F auto_merge=false \
+            -f required_contexts='[]' \
+            --jq '.id')
+          echo "id=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
+          gh api "/repos/${{ github.repository }}/deployments/$DEPLOYMENT_ID/statuses" \
+            --method POST \
+            -f state="in_progress" \
+            -f log_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -102,20 +121,23 @@ jobs:
           remoteDir: ${{ vars.SERVER_TARGET }}/preview/${{ steps.branch.outputs.name }}/
           options: 'verbose=3 delete'
 
-      - name: Post preview URL as PR comment
+      - name: Set deployment status success
+        if: success()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: ${{ steps.branch.outputs.name }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          PREVIEW_URL="https://2lukas.de/preview/$BRANCH/"
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MARKER="<!-- preview-deploy-bot -->"
-          BODY="$MARKER"$'\n'"🚀 **Preview deployed!**"$'\n\n'"→ $PREVIEW_URL"$'\n\n'"_Updated on $(date -u '+%Y-%m-%d %H:%M') UTC · [View run]($RUN_URL)_"
-          EXISTING=$(gh api "/repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
-            --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" 2>/dev/null | head -1)
-          if [ -n "$EXISTING" ]; then
-            gh api --method PATCH "/repos/${{ github.repository }}/issues/comments/$EXISTING" -f body="$BODY"
-          else
-            gh pr comment "$PR_NUMBER" --body "$BODY"
-          fi
+          gh api "/repos/${{ github.repository }}/deployments/${{ steps.deployment.outputs.id }}/statuses" \
+            --method POST \
+            -f state="success" \
+            -f environment_url="https://2lukas.de/preview/${{ steps.branch.outputs.name }}/" \
+            -f log_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Set deployment status failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "/repos/${{ github.repository }}/deployments/${{ steps.deployment.outputs.id }}/statuses" \
+            --method POST \
+            -f state="failure" \
+            -f log_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/preview_deploy.yml
+++ b/.github/workflows/preview_deploy.yml
@@ -43,14 +43,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          DEPLOYMENT_ID=$(gh api "/repos/${{ github.repository }}/deployments" \
-            --method POST \
-            -f ref="${{ github.event.pull_request.head.sha }}" \
-            -f environment="preview/${{ steps.branch.outputs.name }}" \
-            -f description="Preview for PR #${{ github.event.pull_request.number }}" \
-            -F auto_merge=false \
-            -f required_contexts='[]' \
-            --jq '.id')
+          DEPLOYMENT_ID=$(jq -n \
+            --arg ref "${{ github.event.pull_request.head.sha }}" \
+            --arg env "preview/${{ steps.branch.outputs.name }}" \
+            --arg desc "Preview for PR #${{ github.event.pull_request.number }}" \
+            '{"ref":$ref,"environment":$env,"description":$desc,"auto_merge":false,"required_contexts":[]}' \
+          | gh api "/repos/${{ github.repository }}/deployments" --method POST --input - --jq '.id')
           echo "id=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
           gh api "/repos/${{ github.repository }}/deployments/$DEPLOYMENT_ID/statuses" \
             --method POST \
@@ -133,7 +131,7 @@ jobs:
             -f log_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Set deployment status failure
-        if: failure()
+        if: failure() && steps.deployment.outputs.id != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

- Replaces PR comments with native GitHub Deployments API
- After deploy: shows "View deployment" button in PR UI → no email notifications
- On failure: sets deployment status to `failure`
- On PR close/merge: sets all deployments for that environment to `inactive`

## Test plan

- [x] Open a PR → deploy runs → "View deployment" button appears in PR (no email)
- [x] Click "View deployment" → opens preview URL
- [ ] Push another commit → deployment status updates
- [x] Merge/close PR → deployment shows as inactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)