### PR TITLE
fix: skip preview deploy for Dependabot PRs

### DIFF
--- a/.github/workflows/preview_deploy.yml
+++ b/.github/workflows/preview_deploy.yml
@@ -27,6 +27,7 @@ env:
 jobs:
   preview:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Problem

Dependabot PRs fail at the "Create GitHub deployment" step with HTTP 403. Dependabot runs with a restricted `GITHUB_TOKEN` that has no permission to create deployments via the API.

## Fix

Add `if: github.actor != 'dependabot[bot]'` to the `preview` job — the entire job is skipped for Dependabot PRs. No preview deploy is needed for dependency bumps anyway.

## Test plan

- [ ] Merge this — next Dependabot PR should show the preview job as skipped (not failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)