### PR TITLE
build(deps): group dependabot updates, add cooldown and PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,51 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
+    groups:
+      astro:
+        patterns:
+          - "astro"
+          - "@astrojs/*"
+          - "astro-font"
+        update-types:
+          - "minor"
+          - "patch"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+          - "tailwind-merge"
+        update-types:
+          - "minor"
+          - "patch"
+      lint-and-format:
+        patterns:
+          - "eslint*"
+          - "@typescript-eslint/*"
+          - "typescript-eslint"
+          - "prettier*"
+        update-types:
+          - "minor"
+          - "patch"
+      testing:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
+    groups:
+      actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
     cooldown:
       default-days: 3
     groups:
@@ -25,6 +26,7 @@ updates:
           - "tailwindcss"
           - "@tailwindcss/*"
           - "tailwind-merge"
+          - "clsx"
         update-types:
           - "minor"
           - "patch"
@@ -33,7 +35,10 @@ updates:
           - "eslint*"
           - "@typescript-eslint/*"
           - "typescript-eslint"
+          - "typescript"
           - "prettier*"
+          - "husky"
+          - "lint-staged"
         update-types:
           - "minor"
           - "patch"
@@ -41,6 +46,13 @@ updates:
         patterns:
           - "vitest"
           - "@vitest/*"
+        update-types:
+          - "minor"
+          - "patch"
+      pagefind:
+        patterns:
+          - "pagefind"
+          - "@pagefind/*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Summary
- Group minor/patch updates per ecosystem-aligned toolchain: `astro` (astro + @astrojs/* + astro-font), `tailwind` (tailwindcss + @tailwindcss/* + tailwind-merge + clsx), `lint-and-format` (eslint*, @typescript-eslint/*, typescript-eslint, typescript, prettier*, husky, lint-staged), `testing` (vitest + @vitest/*), `pagefind` (pagefind + @pagefind/*), and `actions` for github-actions — cuts PR noise while leaving major version bumps ungrouped for individual review.
- Add a 3-day cooldown (`cooldown.default-days: 3`) on both ecosystems so brand-new releases have time to surface issues before Dependabot opens a PR; security updates are unaffected by cooldown.
- Raise `open-pull-requests-limit` to 10 on the npm ecosystem so grouped and standalone updates don't get silently deferred past the default cap of 5.

## Test plan
- [x] Validated YAML syntax
- [ ] Confirm Dependabot picks up the new groups/cooldown on the next scheduled run