### PR TITLE
chore: move sharp into astro dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
           - "astro"
           - "@astrojs/*"
           - "astro-font"
+          - "sharp"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Summary
- `sharp` is an Astro peer dependency used by the `<Image />` component — it belongs grouped with Astro rather than as a standalone PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXtCVeH5DVXjpdpfkX8SkK