### PR TITLE
fix: correct animate() times array length to match keyframe count

### DIFF
--- a/src/pages/[...lang]/index.astro
+++ b/src/pages/[...lang]/index.astro
@@ -44,7 +44,7 @@ const posts = allPosts.slice(0, MAX_POSTS)
 			{
 				duration: 2.5,
 				opacity: { duration: 3 },
-				times: [0, 0.55, 0.75]
+				times: [0, 0.55]
 			}
 		)
 	}

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -32,7 +32,7 @@ const posts = allPosts.slice(0, MAX_POSTS)
 			{
 				duration: 2.5,
 				opacity: { duration: 3 },
-				times: [0, 0.55, 0.75]
+				times: [0, 0.55]
 			}
 		)
 	}


### PR DESCRIPTION
## Summary

- `times` (formerly `offset` in motion v10) must have the same number of entries as keyframes
- Both index pages had `times: [0, 0.55, 0.75]` — 3 entries for 2-keyframe animations (`y: [80, 0]`, `opacity: [0, 1]`)
- The third value was always silently discarded by the browser per the WAAPI spec, so behavior is unchanged
- Trimmed to `times: [0, 0.55]` to make the intent explicit: animation reaches its final value at 55% of the 2.5s duration

## Background

This bug was introduced by Daniel in Aug 2023 (`e78718dd`). The v10 Motion One types even documented the constraint (`offset` entries must match keyframe count) but didn't enforce it. The third value `0.75` was never doing anything.

## Test plan

- [ ] Visit home page (`/` and `/en/`) on first visit (clear `animations` from localStorage first)
- [ ] Confirm `.title` slides up and fades in, completing at ~1.375s (55% of 2.5s), then holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)