### PR TITLE
fix: category menu active-item underline broken by tailwind-merge v3

### DIFF
--- a/src/components/Category.astro
+++ b/src/components/Category.astro
@@ -32,9 +32,8 @@ const href = url(
 <a
 	href={href}
 	class={cn(
-		`text-gray-600 dark:text-gray-300  pb-2.5 first-letter:uppercase font-medium hover:text-gray-800 border-b-2 border-opacity-0 dark:border-opacity-0 border-black dark:border-white dark:hover:border-white hover:border-opacity-100 transition-colors duration-150 ease-linear  `,
-		isActive &&
-			`border-black border-b-2 text-black z-10  dark:border-white dark:text-white dark:border-opacity-100 border-opacity-100`
+		`text-gray-600 dark:text-gray-300 pb-2.5 first-letter:uppercase font-medium hover:text-gray-800 border-b-2 border-transparent hover:border-black dark:hover:border-white transition-colors duration-150 ease-linear`,
+		isActive && `border-black dark:border-white text-black z-10 dark:text-white`
 	)}
 >
 	{displayName}

--- a/src/components/Category.astro
+++ b/src/components/Category.astro
@@ -32,7 +32,7 @@ const href = url(
 <a
 	href={href}
 	class={cn(
-		`text-gray-600 dark:text-gray-300 pb-2.5 first-letter:uppercase font-medium hover:text-gray-800 border-b-2 border-transparent hover:border-black dark:hover:border-white transition-colors duration-150 ease-linear`,
+		`text-gray-600 dark:text-gray-300 pb-2.5 first-letter:uppercase font-medium hover:text-gray-800 dark:hover:text-white border-b-2 border-transparent hover:border-black dark:hover:border-white transition-colors duration-150 ease-linear`,
 		isActive && `border-black dark:border-white text-black z-10 dark:text-white`
 	)}
 >

--- a/src/components/Category.test.ts
+++ b/src/components/Category.test.ts
@@ -1,0 +1,50 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+import { describe, it, expect } from 'vitest'
+import Category from './Category.astro'
+
+function classesOf(html: string): string[] {
+	const match = html.match(/class="([^"]*)"/)
+	if (!match) throw new Error(`no class attribute found in: ${html}`)
+	return match[1].split(/\s+/)
+}
+
+describe('Category', () => {
+	it('gives the active category a visible border, distinct from inactive ones', async () => {
+		const container = await AstroContainer.create()
+
+		const activeClasses = classesOf(
+			await container.renderToString(Category, {
+				props: { name: 'Football Manager', activeCategory: 'football-manager' }
+			})
+		)
+		const inactiveClasses = classesOf(
+			await container.renderToString(Category, {
+				props: { name: 'Projects', activeCategory: 'football-manager' }
+			})
+		)
+
+		// active link: solid border, no leftover transparent override
+		expect(activeClasses).toContain('border-black')
+		expect(activeClasses).not.toContain('border-transparent')
+
+		// inactive link: border hidden until hover, never plain border-black
+		expect(inactiveClasses).toContain('border-transparent')
+		expect(inactiveClasses).not.toContain('border-black')
+
+		// the two states must not render identically (this is what the
+		// tailwind-merge v3 upgrade broke: both ended up with the same
+		// always-visible border, hiding which category was selected)
+		expect(activeClasses).not.toEqual(inactiveClasses)
+	})
+
+	it('treats "View All" as active on the German homepage', async () => {
+		const container = await AstroContainer.create()
+
+		const html = await container.renderToString(Category, {
+			props: { name: 'View All' },
+			request: new Request('https://2lukas.de/')
+		})
+
+		expect(classesOf(html)).toContain('border-black')
+	})
+})

--- a/src/components/Category.test.ts
+++ b/src/components/Category.test.ts
@@ -47,4 +47,18 @@ describe('Category', () => {
 
 		expect(classesOf(html)).toContain('border-black')
 	})
+
+	it('keeps hover text readable in dark mode', async () => {
+		const container = await AstroContainer.create()
+
+		const classes = classesOf(
+			await container.renderToString(Category, {
+				props: { name: 'Projects', activeCategory: 'football-manager' }
+			})
+		)
+
+		// hover:text-gray-800 with no dark: variant made hover text nearly
+		// black-on-black in dark mode; dark:hover:text-white must be present
+		expect(classes).toContain('dark:hover:text-white')
+	})
 })

--- a/src/components/ListCategories.astro
+++ b/src/components/ListCategories.astro
@@ -14,5 +14,8 @@ const { activeCategory } = Astro.props
 		))
 	}
 
-	<div class='hidden sm:block absolute w-full bottom-0 border-b-2 -z-40 dark:border-gray-600'></div>
+	<div
+		class='hidden sm:block absolute w-full bottom-0 border-b-2 border-gray-200 -z-40 dark:border-gray-600'
+	>
+	</div>
 </div>

--- a/src/components/ListCategories.test.ts
+++ b/src/components/ListCategories.test.ts
@@ -1,0 +1,48 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+import { describe, it, expect, vi } from 'vitest'
+import type { CollectionEntry } from 'astro:content'
+
+vi.mock('astro:content', () => ({
+	getCollection: vi.fn()
+}))
+
+import { getCollection } from 'astro:content'
+import ListCategories from './ListCategories.astro'
+
+const mockGetCollection = vi.mocked(getCollection)
+
+function makePost(id: string, category: string): CollectionEntry<'blog'> {
+	return {
+		id,
+		body: '',
+		collection: 'blog',
+		data: {
+			title: `Post ${id}`,
+			description: 'desc',
+			pubDate: new Date('2026-01-01'),
+			category,
+			tags: [],
+			draft: false
+		}
+	} as unknown as CollectionEntry<'blog'>
+}
+
+describe('ListCategories', () => {
+	it('gives the always-visible divider an explicit light-mode color', async () => {
+		mockGetCollection.mockResolvedValue([makePost('a.md', 'Projects')])
+
+		const container = await AstroContainer.create()
+		const html = await container.renderToString(ListCategories, { props: {} })
+
+		const match = html.match(/<div class="([^"]*-z-40[^"]*)"><\/div>/)
+		expect(match).not.toBeNull()
+		const dividerClasses = match![1].split(/\s+/)
+
+		// a border-b-2 with no light-mode color class falls back to
+		// currentColor (effectively black), which is indistinguishable
+		// from the active category's own border-black — swallowing the
+		// active-category indicator in light mode
+		expect(dividerClasses.some((c) => /^border-gray-\d+$/.test(c))).toBe(true)
+		expect(dividerClasses.some((c) => /^dark:border-gray-\d+$/.test(c))).toBe(true)
+	})
+})


### PR DESCRIPTION
## Summary
- The active-category underline in the landing page category menu (`src/components/Category.astro`) stopped working after the `tailwind-merge` 2.0.0 → 3.6.0 bump (#69): v3 treats `border-opacity-*` and `border-{color}` as the same conflict group, so it silently dropped the `border-opacity-0`/`dark:border-opacity-0` classes that hid the bottom border on inactive links. Every category ended up with the same always-visible border, masking which one was selected.
- Replaced the color+opacity pairing with a single class per state (`border-transparent` inactive vs `border-black`/`dark:border-white` active), which `twMerge` v3 resolves correctly.
- Added a regression test using Astro's container API that renders `Category.astro` and asserts the active link's classes differ from inactive ones. Verified it fails against the pre-fix component and passes against the fix.

## Test plan
- [x] `pnpm test` — 67 tests pass, including the new `Category.test.ts`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] Confirmed live production HTML matched the bug (inactive links all rendered a full-opacity `border-black`/`border-white`)
- [x] Visual check on the preview deploy: click through each category and confirm only the selected one shows the underline

🤖 Generated with [Claude Code](https://claude.com/claude-code)